### PR TITLE
Add reset password to client

### DIFF
--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -477,6 +477,26 @@ namespace Supabase.Gotrue
                 throw ExceptionHandler.Parse(ex);
             }
         }
+        
+        /// <summary>
+        /// Sends a reset request to an email address.
+        /// </summary>
+        /// <param name="email"></param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        public async Task<bool> ResetPasswordForEmail(string email)
+        {
+            try
+            {
+                var result = await api.ResetPasswordForEmail(email);
+                result.ResponseMessage.EnsureSuccessStatusCode();
+                return true;
+            }
+            catch (RequestException ex)
+            {
+                throw ExceptionHandler.Parse(ex);
+            }
+        }
 
         /// <summary>
         /// Refreshes the currently logged in User's Session.

--- a/GotrueTests/Client.cs
+++ b/GotrueTests/Client.cs
@@ -266,5 +266,14 @@ namespace GotrueTests
 
             Assert.IsTrue(result);
         }
+        
+        [TestMethod("Client: Sends Reset Password Email")]
+        public async Task ClientSendsResetPasswordForEmail()
+        {
+            var email = $"{RandomString(12)}@supabase.io";
+            await client.SignUp(email, password);
+            var result = await client.ResetPasswordForEmail(email);
+            Assert.IsTrue(result);
+        }
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds delete user to client, additional oauth providers and addresses failing to initialise the test stack in GitHub action

## What is the current behavior?

- Missing reset password email on the client

## What is the new behavior?

-  Added ResetPasswordForEmail functionality to client
