### PR TITLE
Added SignOut method to Stateless Client

### DIFF
--- a/Gotrue/StatelessClient.cs
+++ b/Gotrue/StatelessClient.cs
@@ -175,6 +175,28 @@ namespace Supabase.Gotrue
         public static string SignIn(Provider provider, StatelessClientOptions options, string scopes = null) => GetApi(options).GetUrlForProvider(provider, scopes);
 
         /// <summary>
+        /// Logout a User
+        /// This will revoke all refresh tokens for the user.
+        /// JWT tokens will still be valid for stateless auth until they expire.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="accessToken"></param>
+        /// <returns></returns>
+        public static async Task<bool> SignOut(string accessToken, StatelessClientOptions options)
+        {
+            try
+            {
+                var result = await GetApi(options).SignOut(accessToken);
+                result.ResponseMessage.EnsureSuccessStatusCode();
+                return true;
+            }
+            catch (RequestException ex)
+            {
+                throw ExceptionHandler.Parse(ex);
+            }
+        }
+
+        /// <summary>
         /// Log in a user given a User supplied OTP received via mobile.
         /// </summary>
         /// <param name="phone">The user's phone number.</param>

--- a/Gotrue/StatelessClient.cs
+++ b/Gotrue/StatelessClient.cs
@@ -182,11 +182,11 @@ namespace Supabase.Gotrue
         /// <param name="options"></param>
         /// <param name="accessToken"></param>
         /// <returns></returns>
-        public static async Task<bool> SignOut(string accessToken, StatelessClientOptions options)
+        public static async Task<bool> SignOut(string jwt, StatelessClientOptions options)
         {
             try
             {
-                var result = await GetApi(options).SignOut(accessToken);
+                var result = await GetApi(options).SignOut(jwt);
                 result.ResponseMessage.EnsureSuccessStatusCode();
                 return true;
             }

--- a/GotrueTests/StatelessClient.cs
+++ b/GotrueTests/StatelessClient.cs
@@ -131,6 +131,26 @@ namespace GotrueTests
             Assert.IsInstanceOfType(newSession.User, typeof(User));
         }
 
+        [TestMethod("StatelessClient: Signs Out User (Email)")]
+        public async Task SignsOut()
+        {
+            Session session = null;
+
+            // Emails
+            var email = $"{RandomString(12)}@supabase.io";
+            await SignUp(email, password, options);
+
+
+            session = await SignIn(email, password, options);
+
+            Assert.IsNotNull(session.AccessToken);
+            Assert.IsInstanceOfType(session.User, typeof(User));
+
+            var result = await SignOut(session.AccessToken, options);
+
+            Assert.IsTrue(result);
+        }
+
         [TestMethod("StatelessClient: Sends Magic Login Email")]
         public async Task SendsMagicLoginEmail()
         {


### PR DESCRIPTION
Added SignOut method to `StatelessClient` based on the description [here](https://github.com/supabase/gotrue#post-logout). 
The API method existed but was missing implementation on the `StatelessClient ` class. I also added a test method but was having issues running the test projects. 