### PR TITLE
Change attribute name to user_metadata

### DIFF
--- a/Gotrue/User.cs
+++ b/Gotrue/User.cs
@@ -124,7 +124,7 @@ namespace Supabase.Gotrue
         /// <summary>
         /// A custom data object for user_metadata that a user can modify.Can be any JSON.
         /// </summary>
-        [JsonProperty("data")]
+        [JsonProperty("user_metadata")]
         public Dictionary<string, object> Data { get; set; } = new Dictionary<string, object>();
     }
 


### PR DESCRIPTION
Couldn't get custom metadata to work by calling UpdateUserById as follows:

```csharp
    public Task<User> ConfirmRegistration(string userId, string supabaseId)
    {
        var attributes = new UserAttributes
        {
            Data = new Dictionary<string, object>
            {
                {"user_id", userId}
            }
        };
        return _supabaseClient.Auth.UpdateUserById(_supabaseClient.SupabaseKey, supabaseId, attributes);
    }
```
After comparing gotrue-csharp and gotrue-js libraries I figured out that having the attribute as "data" doesn't really do anything. Changing it as in my commit fixed it - tested locally