### PR TITLE
Fixes #29 by changing `redirect_to` into a query parameter instead of…

### DIFF
--- a/Gotrue/Api.cs
+++ b/Gotrue/Api.cs
@@ -44,11 +44,13 @@ namespace Supabase.Gotrue
         {
             var body = new Dictionary<string, object> { { "email", email }, { "password", password } };
 
+            string endpoint = $"{Url}/signup";
+
             if (options != null)
-            {   
+            {
                 if (!string.IsNullOrEmpty(options.RedirectTo))
                 {
-                    body.Add("redirectTo", options.RedirectTo);
+                    endpoint = Helpers.AddQueryParams(endpoint, new Dictionary<string, string> { { "redirect_to", options.RedirectTo } }).ToString();
                 }
 
                 if (options.Data != null)
@@ -57,7 +59,7 @@ namespace Supabase.Gotrue
                 }
             }
 
-            var response = await Helpers.MakeRequest(HttpMethod.Post, $"{Url}/signup", body, Headers);
+            var response = await Helpers.MakeRequest(HttpMethod.Post, endpoint, body, Headers);
 
             // Gotrue returns a Session object for an auto-/pre-confirmed account
             var session = JsonConvert.DeserializeObject<Session>(response.Content);
@@ -94,15 +96,18 @@ namespace Supabase.Gotrue
         public Task<BaseResponse> SendMagicLinkEmail(string email, SignInOptions options = null)
         {
             var data = new Dictionary<string, string> { { "email", email } };
+
+            string endpoint = $"{Url}/magiclink";
+
             if (options != null)
             {
                 if (!string.IsNullOrEmpty(options.RedirectTo))
                 {
-                    data.Add("redirect_to", options.RedirectTo);
+                    endpoint = Helpers.AddQueryParams(endpoint, new Dictionary<string, string> { { "redirect_to", options.RedirectTo } }).ToString();
                 }
             }
 
-            return Helpers.MakeRequest(HttpMethod.Post, $"{Url}/magiclink", data, Headers);
+            return Helpers.MakeRequest(HttpMethod.Post, endpoint, data, Headers);
         }
 
         /// <summary>
@@ -131,11 +136,13 @@ namespace Supabase.Gotrue
                 { "password", password },
             };
 
+            string endpoint = $"{Url}/signup";
+
             if (options != null)
             {
                 if (!string.IsNullOrEmpty(options.RedirectTo))
                 {
-                    body.Add("redirectTo", options.RedirectTo);
+                    endpoint = Helpers.AddQueryParams(endpoint, new Dictionary<string, string> { { "redirect_to", options.RedirectTo } }).ToString();
                 }
 
                 if (options.Data != null)
@@ -144,7 +151,7 @@ namespace Supabase.Gotrue
                 }
             }
 
-            return Helpers.MakeRequest<Session>(HttpMethod.Post, $"{Url}/signup", body, Headers);
+            return Helpers.MakeRequest<Session>(HttpMethod.Post, endpoint, body, Headers);
         }
 
         /// <summary>

--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -640,7 +640,7 @@ namespace Supabase.Gotrue
         /// <returns></returns>
         public async Task<Session> GetSessionFromUrl(Uri uri, bool storeSession = true)
         {
-            var query = HttpUtility.ParseQueryString(uri.Query);
+            var query = string.IsNullOrEmpty(uri.Fragment) ? HttpUtility.ParseQueryString(uri.Query) : HttpUtility.ParseQueryString('?' + uri.Fragment.TrimStart('#'));
 
             var errorDescription = query.Get("error_description");
 

--- a/Gotrue/Helpers.cs
+++ b/Gotrue/Helpers.cs
@@ -28,6 +28,25 @@ namespace Supabase.Gotrue
             return type.GetField(name).GetCustomAttributes(false).OfType<MapToAttribute>().SingleOrDefault();
         }
 
+        /// <summary>
+        /// Adds query params to a given Url
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        internal static Uri AddQueryParams(string url, Dictionary<string, string> data)
+        {
+            var builder = new UriBuilder(url);
+            var query = HttpUtility.ParseQueryString(builder.Query);
+
+            foreach (var param in data)
+                query[param.Key] = param.Value;
+
+            builder.Query = query.ToString();
+
+            return builder.Uri;
+        }
+
         private static readonly HttpClient client = new HttpClient();
 
         /// <summary>


### PR DESCRIPTION
Inspired by #30.

Fixes #29 by changing `redirect_to` into a query parameter instead of POST data.
`GetSessionFromUrl` accounts for gotrue sending a url of the format: `http://localhost:9000?status=success#access_token=blahblah`