### PR TITLE
Refresh timer should be cancelled if the user logs out

### DIFF
--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -427,6 +427,8 @@ namespace Supabase.Gotrue
             if (CurrentSession != null)
             {
                 await api.SignOut(CurrentSession.AccessToken);
+                if (refreshTimer != null)
+                    refreshTimer.Dispose();
                 await DestroySession();
                 StateChanged?.Invoke(this, new ClientStateChanged(AuthState.SignedOut));
             }
@@ -776,7 +778,7 @@ namespace Supabase.Gotrue
         /// <returns></returns>
         internal async Task RefreshToken(string refreshToken = null)
         {
-            if (string.IsNullOrEmpty(CurrentSession.RefreshToken) && string.IsNullOrEmpty(refreshToken))
+            if (string.IsNullOrEmpty(CurrentSession?.RefreshToken) && string.IsNullOrEmpty(refreshToken))
                 throw new Exception("No current session.");
 
             refreshToken ??= CurrentSession.RefreshToken;


### PR DESCRIPTION
When a user logs out, currently the refresh timer will stay active. If the user were to somehow wait on a login screen the app would crash. Probably a minimal edge-case but I discovered it during testing after taking a break.

This also fixes a minor bug introduced by my last PR, where the CurrentSession object can still be null, causing the IsNullOrEmpty check to fail.