### PR TITLE
Debug info for RetrieveSessionAsync, allow options update

### DIFF
--- a/Gotrue/ClientOptions.cs
+++ b/Gotrue/ClientOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using Supabase.Gotrue.Interfaces;
 using static Supabase.Gotrue.Constants;
 
 namespace Supabase.Gotrue

--- a/Gotrue/Exceptions/FailureReason.cs
+++ b/Gotrue/Exceptions/FailureReason.cs
@@ -7,22 +7,74 @@ namespace Supabase.Gotrue.Exceptions
 	/// </summary>
 	public static class FailureHint
 	{
+		/// <summary>
+		/// Best effort guess at why the exception was thrown.
+		/// </summary>
 		public enum Reason
 		{
+			/// <summary>
+			/// The reason for the error could not be determined.
+			/// </summary>
 			Unknown,
+			/// <summary>
+			/// The user's email address has not been confirmed.
+			/// </summary>
 			UserEmailNotConfirmed,
+			/// <summary>
+			/// The user's email address and password are invalid.
+			/// </summary>
 			UserBadMultiple,
+			/// <summary>
+			/// The user's password is invalid.
+			/// </summary>
 			UserBadPassword,
+			/// <summary>
+			/// The user's login is invalid.
+			/// </summary>
 			UserBadLogin,
+			/// <summary>
+			/// The user's email address is invalid.
+			/// </summary>
 			UserBadEmailAddress,
+			/// <summary>
+			/// The user's phone number is invalid.
+			/// </summary>
 			UserBadPhoneNumber,
+			/// <summary>
+			/// The user's information is incomplete.
+			/// </summary>
 			UserMissingInformation,
+			/// <summary>
+			/// The user is already registered.
+			/// </summary>
 			UserAlreadyRegistered,
+			/// <summary>
+			/// Server rejected due to number of requests
+			/// </summary>
 			UserTooManyRequests,
+			/// <summary>
+			/// The refresh token is invalid.
+			/// </summary>
 			InvalidRefreshToken,
-			AdminTokenRequired
+			/// <summary>
+			/// This operation requires a bearer/service key (do not include this key in a client app)
+			/// </summary>
+			AdminTokenRequired,
+			/// <summary>
+			/// No/invalid session found
+			/// </summary>
+			NoSessionFound,
+			/// <summary>
+			/// Something wrong with the URL to session transformation
+			/// </summary>
+			BadSessionUrl
 		}
 
+		/// <summary>
+		/// Detects the reason for the error based on the status code and the contents of the error message.
+		/// </summary>
+		/// <param name="gte"></param>
+		/// <returns></returns>
 		public static Reason DetectReason(GotrueException gte)
 		{
 			if (gte.Content == null)

--- a/Gotrue/Exceptions/GotrueException.cs
+++ b/Gotrue/Exceptions/GotrueException.cs
@@ -8,19 +8,53 @@ namespace Supabase.Gotrue.Exceptions
 	/// </summary>
 	public class GotrueException : Exception
 	{
+		/// <summary>
+		/// Something with wrong with Gotrue / Auth
+		/// </summary>
+		/// <param name="message">Short description of the error source</param>
 		public GotrueException(string? message) : base(message) { }
+		/// <summary>
+		/// Something with wrong with Gotrue / Auth
+		/// </summary>
+		/// <param name="message">Short description of the error source</param>
+		/// <param name="innerException">The underlying exception</param>
 		public GotrueException(string? message, Exception? innerException) : base(message, innerException) { }
+		/// <summary>
+		/// Something with wrong with Gotrue / Auth
+		/// </summary>
+		/// <param name="message">Short description of the error source</param>
+		/// <param name="reason">Best effort attempt to detect the reason for the failure</param>
+		public GotrueException(string? message, FailureHint.Reason reason) : base(message)
+		{
+			Reason = reason;
+		}
 
+		/// <summary>
+		/// The HTTP response from the server
+		/// </summary>
 		public HttpResponseMessage? Response { get; internal set; }
 
+		/// <summary>
+		/// The content of the HTTP response from the server
+		/// </summary>
 		public string? Content { get; internal set; }
 
+		/// <summary>
+		/// The HTTP status code from the server
+		/// </summary>
 		public int StatusCode { get; internal set; }
+
+		/// <summary>
+		/// Adds the best-effort reason for the failure 
+		/// </summary>
 		public void AddReason()
 		{
 			Reason = FailureHint.DetectReason(this);
 			//Debug.WriteLine(Content);
 		}
+		/// <summary>
+		/// Best guess at what caused the error from the server, see <see cref="FailureHint.Reason"/>
+		/// </summary>
 		public FailureHint.Reason Reason { get; private set; }
 	}
 }

--- a/Gotrue/Interfaces/IGotrueClient.cs
+++ b/Gotrue/Interfaces/IGotrueClient.cs
@@ -5,28 +5,108 @@ using static Supabase.Gotrue.Constants;
 
 namespace Supabase.Gotrue.Interfaces
 {
+	/// <summary>
+	/// Interface for the Gotrue Client (auth).
+	///
+	/// For more information check out the <see cref="Client"/> implementation.
+	/// </summary>
+	/// <typeparam name="TUser"></typeparam>
+	/// <typeparam name="TSession"></typeparam>
 	public interface IGotrueClient<TUser, TSession> : IGettableHeaders
 		where TUser : User
 		where TSession : Session
 	{
+		/// <summary>
+		/// The current in-memory session.
+		/// </summary>
 		TSession? CurrentSession { get; }
+		/// <summary>
+		/// The current in-memory user.
+		/// </summary>
 		TUser? CurrentUser { get; }
 
+		/// <summary>
+		/// The method that is called when there is a user state change.
+		/// </summary>
 		delegate void AuthEventHandler(IGotrueClient<TUser, TSession> sender, AuthState stateChanged);
 
+		/// <summary>
+		/// Sets the persistence implementation for the client (e.g. file system, local storage, etc).
+		/// </summary>
+		/// <param name="persistence"></param>
 		void SetPersistence(IGotrueSessionPersistence<TSession> persistence);
 
+		/// <summary>
+		/// Adds a listener for the user state change event.
+		/// </summary>
+		/// <param name="authEventHandler"></param>
 		void AddStateChangedListener(AuthEventHandler authEventHandler);
+		/// <summary>
+		/// Removes a listener for the user state change event.
+		/// </summary>
+		/// <param name="authEventHandler"></param>
 		void RemoveStateChangedListener(AuthEventHandler authEventHandler);
+		/// <summary>
+		/// Removes all listeners for the user state change event - including the persistence listener.
+		/// </summary>
 		void ClearStateChangedListeners();
+		/// <summary>
+		/// Notifies all listeners of a user state change. This is called internally by the client.
+		/// </summary>
+		/// <param name="stateChanged"></param>
 		void NotifyAuthStateChange(AuthState stateChanged);
 
+		/// <summary>
+		/// Creates a user using the admin key (not the anonymous key).
+		/// Used in trusted server environments, not client apps.
+		/// </summary>
+		/// <param name="jwt">Admin token</param>
+		/// <param name="attributes"></param>
+		/// <returns></returns>
 		Task<TUser?> CreateUser(string jwt, AdminUserAttributes attributes);
+		/// <summary>
+		/// Creates a user using the admin key (not the anonymous key).
+		/// Used in trusted server environments, not client apps.
+		/// </summary>
+		/// <param name="jwt">Admin Bearer token</param>
+		/// <param name="email"></param>
+		/// <param name="password"></param>
+		/// <param name="attributes"></param>
+		/// <returns></returns>
 		Task<TUser?> CreateUser(string jwt, string email, string password, AdminUserAttributes? attributes = null);
+		/// <summary>
+		/// Creates a user using the admin key (not the anonymous key).
+		/// Used in trusted server environments, not client apps.
+		/// </summary>
+
 		Task<bool> DeleteUser(string uid, string jwt);
+		/// <summary>
+		/// Converts a URL to a session. For client apps, this probably requires setting up URL handlers.
+		/// </summary>
+		/// <param name="uri"></param>
+		/// <param name="storeSession"></param>
+		/// <returns></returns>
 		Task<TSession?> GetSessionFromUrl(Uri uri, bool storeSession = true);
+		
+		/// <summary>
+		/// Gets a user from the JWT.
+		/// </summary>
+		/// <param name="jwt"></param>
+		/// <returns></returns>
 		Task<TUser?> GetUser(string jwt);
+		/// <summary>
+		/// Gets a user by ID from the server using the admin key (not the anonymous key).
+		/// </summary>
+		/// <param name="jwt"></param>
+		/// <param name="userId"></param>
+		/// <returns></returns>
 		Task<TUser?> GetUserById(string jwt, string userId);
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="email"></param>
+		/// <param name="jwt"></param>
+		/// <returns></returns>
 		Task<bool> InviteUserByEmail(string email, string jwt);
 		Task<UserList<TUser>?> ListUsers(string jwt, string? filter = null, string? sortBy = null, SortOrder sortOrder = SortOrder.Descending, int? page = null, int? perPage = null);
 		Task<TSession?> RefreshSession();
@@ -51,8 +131,24 @@ namespace Supabase.Gotrue.Interfaces
 		Task<TUser?> UpdateUserById(string jwt, string userId, AdminUserAttributes userData);
 		Task<TSession?> VerifyOTP(string phone, string token, MobileOtpType type = MobileOtpType.SMS);
 		Task<TSession?> VerifyOTP(string email, string token, EmailOtpType type = EmailOtpType.MagicLink);
+		/// <summary>
+		/// Adds a listener for debug messages (e.g. background threads).
+		/// </summary>
+		/// <param name="logDebug"></param>
 		void AddDebugListener(Action<string, Exception?> logDebug);
+		/// <summary>
+		/// Loads the session from the persistence layer.
+		/// </summary>
 		void LoadSession();
+		/// <summary>
+		/// Fetch the server options.
+		/// </summary>
+		/// <returns></returns>
 		Task<Settings?> Settings();
+		/// <summary>
+		/// Returns the client options.
+		/// </summary>
+		ClientOptions Options { get; }
+
 	}
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds debug info (message & exception) to help sort out RetrieveSessionAsync issues.

Also adds some minor tweaks to generated exceptions (instead of just throwing Exception throws GotrueException w/added reasons).

Adds minor extra docs.

Adds options to the interface, allowing option to update AllowUnconfirmedUserSessions. This allows a flow where the client can launch the client, retrieve the settings to see if AllowUnconfirmed is set, and then update/manage as needed.

No API changes (any user catching an Exception will just get a slightly more specialized exception).