### PR TITLE
Split into admin and regular client. Minor doc fixes. Lock lang to 9.0

### DIFF
--- a/Gotrue/AdminClient.cs
+++ b/Gotrue/AdminClient.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Supabase.Gotrue.Interfaces;
+namespace Supabase.Gotrue
+{
+	/// <summary>
+	/// Admin client for interacting with the Gotrue API. Intended for use on
+	/// servers or other secure environments.
+	///
+	/// This client does NOT manage user sessions or track any other state.
+	/// </summary>
+	public class AdminClient : IGotrueAdminClient<User>
+	{
+		/// <summary>
+		/// The initialized client options.
+		/// </summary>
+		public ClientOptions Options { get; }
+
+		/// <summary>
+		/// Initialize the client with a service key. 
+		/// </summary>
+		/// <param name="serviceKey">A valid JWT. Must be a full-access API key (e.g. 'service_role' or 'supabase_admin'). </param>
+		/// <param name="options"></param>
+		public AdminClient(string serviceKey, ClientOptions? options = null)
+		{
+			_serviceKey = serviceKey;
+
+			options ??= new ClientOptions();
+			Options = options;
+			_api = new Api(options.Url, options.Headers);
+		}
+
+		/// <summary>
+		/// Headers sent to the API on every request.
+		/// </summary>
+		public Func<Dictionary<string, string>>? GetHeaders
+		{
+			get => _api.GetHeaders;
+			set => _api.GetHeaders = value;
+		}
+
+		/// <summary>
+		/// The underlying API requests object that sends the requests
+		/// </summary>
+		private readonly IGotrueApi<User, Session> _api;
+
+		/// <summary>
+		/// The service key used to authenticate with the API.
+		/// </summary>
+		private readonly string _serviceKey;
+
+		/// <inheritdoc />
+		public Task<User?> GetUserById(string userId) => _api.GetUserById(_serviceKey, userId);
+
+		/// <inheritdoc />
+		public Task<User?> GetUser(string jwt) => _api.GetUser(jwt);
+
+		/// <inheritdoc />
+		public async Task<bool> InviteUserByEmail(string email)
+		{
+			var response = await _api.InviteUserByEmail(email, _serviceKey);
+			response.ResponseMessage?.EnsureSuccessStatusCode();
+			return true;
+		}
+
+		/// <inheritdoc />
+		public async Task<bool> DeleteUser(string uid)
+		{
+			var result = await _api.DeleteUser(uid, _serviceKey);
+			result.ResponseMessage?.EnsureSuccessStatusCode();
+			return true;
+		}
+
+		/// <inheritdoc />
+		public Task<User?> CreateUser(string email, string password, AdminUserAttributes? attributes = null)
+		{
+			attributes ??= new AdminUserAttributes();
+			attributes.Email = email;
+			attributes.Password = password;
+
+			return CreateUser(attributes);
+		}
+
+		/// <inheritdoc />
+		public Task<User?> CreateUser(AdminUserAttributes attributes) => _api.CreateUser(_serviceKey, attributes);
+
+		/// <inheritdoc />
+		public Task<UserList<User>?> ListUsers(string? filter = null, string? sortBy = null, Constants.SortOrder sortOrder = Constants.SortOrder.Descending, int? page = null, int? perPage = null)
+		{
+			return _api.ListUsers(_serviceKey, filter, sortBy, sortOrder, page, perPage);
+		}
+
+		/// <inheritdoc />
+		public Task<User?> UpdateUserById(string userId, AdminUserAttributes userData)
+		{
+			return _api.UpdateUserById(_serviceKey, userId, userData);
+		}
+
+		/// <inheritdoc />
+		public async Task<User?> Update(UserAttributes attributes)
+		{
+			var result = await _api.UpdateUser(_serviceKey, attributes);
+			return result;
+		}
+	}
+}

--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -106,6 +106,14 @@ namespace Supabase.Gotrue
 		public ClientOptions Options { get; }
 
 		/// <summary>
+		/// Get User details by JWT. Can be used to validate a JWT.
+		/// </summary>
+		/// <param name="jwt">A valid JWT. Must be a JWT that originates from a user.</param>
+		/// <returns></returns>
+		public Task<User?> GetUser(string jwt) => _api.GetUser(jwt);
+
+		
+		/// <summary>
 		/// Notifies all listeners that the current user auth state has changed.
 		///
 		/// This is mainly used internally to fire notifications - most client applications won't need this.
@@ -535,95 +543,8 @@ namespace Supabase.Gotrue
 			return response.ResponseMessage?.IsSuccessStatusCode ?? false;
 		}
 
-		/// <summary>
-		/// Sends an invite email link to the specified email.
-		/// </summary>
-		/// <param name="email"></param>
-		/// <param name="jwt">this token needs role 'supabase_admin' or 'service_role'</param>
-		/// <returns></returns>
-		public async Task<bool> InviteUserByEmail(string email, string jwt)
-		{
-			var response = await _api.InviteUserByEmail(email, jwt);
-			response.ResponseMessage?.EnsureSuccessStatusCode();
-			return true;
-		}
-
-		/// <summary>
-		/// Deletes a User.
-		/// </summary>
-		/// <param name="uid"></param>
-		/// <param name="jwt">this token needs role 'supabase_admin' or 'service_role'</param>
-		/// <returns></returns>
-		public async Task<bool> DeleteUser(string uid, string jwt)
-		{
-			var result = await _api.DeleteUser(uid, jwt);
-			result.ResponseMessage?.EnsureSuccessStatusCode();
-			return true;
-		}
-
-		/// <summary>
-		/// Lists users
-		/// </summary>
-		/// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
-		/// <param name="filter">A string for example part of the email</param>
-		/// <param name="sortBy">Snake case string of the given key, currently only created_at is supported</param>
-		/// <param name="sortOrder">asc or desc, if null desc is used</param>
-		/// <param name="page">page to show for pagination</param>
-		/// <param name="perPage">items per page for pagination</param>
-		/// <returns></returns>
-		public Task<UserList<User>?> ListUsers(string jwt, string? filter = null, string? sortBy = null, SortOrder sortOrder = SortOrder.Descending, int? page = null,
-			int? perPage = null) => _api.ListUsers(jwt, filter, sortBy, sortOrder, page, perPage);
-
-		/// <summary>
-		/// Get User details by Id
-		/// </summary>
-		/// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
-		/// <param name="userId"></param>
-		/// <returns></returns>
-		public Task<User?> GetUserById(string jwt, string userId) => _api.GetUserById(jwt, userId);
-
-		/// <summary>
-		/// Get User details by JWT. Can be used to validate a JWT.
-		/// </summary>
-		/// <param name="jwt">A valid JWT. Must be a JWT that originates from a user.</param>
-		/// <returns></returns>
-		public Task<User?> GetUser(string jwt) => _api.GetUser(jwt);
-
-		/// <summary>
-		/// Create a user (as a service_role)
-		/// </summary>
-		/// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
-		/// <param name="email"></param>
-		/// <param name="password"></param>
-		/// <param name="attributes"></param>
-		/// <returns></returns>
-		public Task<User?> CreateUser(string jwt, string email, string password, AdminUserAttributes? attributes = null)
-		{
-			attributes ??= new AdminUserAttributes();
-			attributes.Email = email;
-			attributes.Password = password;
-
-			return CreateUser(jwt, attributes);
-		}
-
-
-		/// <summary>
-		/// Create a user (as a service_role)
-		/// </summary>
-		/// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
-		/// <param name="attributes"></param>
-		/// <returns></returns>
-		public Task<User?> CreateUser(string jwt, AdminUserAttributes attributes) => _api.CreateUser(jwt, attributes);
-
-		/// <summary>
-		/// Update user by Id
-		/// </summary>
-		/// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
-		/// <param name="userId"></param>
-		/// <param name="userData"></param>
-		/// <returns></returns>
-		public Task<User?> UpdateUserById(string jwt, string userId, AdminUserAttributes userData) => _api.UpdateUserById(jwt, userId, userData);
-
+	
+		
 		/// <summary>
 		/// Sends a reset request to an email address.
 		/// </summary>

--- a/Gotrue/Constants.cs
+++ b/Gotrue/Constants.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Supabase.Core.Attributes;
+#pragma warning disable CS1591
 
 namespace Supabase.Gotrue
 {

--- a/Gotrue/Exceptions/FailureReason.cs
+++ b/Gotrue/Exceptions/FailureReason.cs
@@ -95,6 +95,7 @@ namespace Supabase.Gotrue.Exceptions
 				400 when gte.Content.Contains("User already registered") => UserAlreadyRegistered,
 				400 when gte.Content.Contains("Invalid Refresh Token") => InvalidRefreshToken,
 				401 when gte.Content.Contains("This endpoint requires a Bearer token") => AdminTokenRequired,
+				401 when gte.Content.Contains("Invalid token") => AdminTokenRequired,
 				422 when gte.Content.Contains("Phone") && gte.Content.Contains("Email") => UserBadMultiple,
 				422 when gte.Content.Contains("email") && gte.Content.Contains("password") => UserBadMultiple,
 				422 when gte.Content.Contains("Phone") => UserBadPhoneNumber,

--- a/Gotrue/Gotrue.csproj
+++ b/Gotrue/Gotrue.csproj
@@ -32,7 +32,7 @@
     </PropertyGroup>
     <PropertyGroup>
         <Nullable>enable</Nullable>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>9.0</LangVersion>
         <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
     </PropertyGroup>
     <PropertyGroup>

--- a/Gotrue/Helpers.cs
+++ b/Gotrue/Helpers.cs
@@ -13,7 +13,7 @@ using Supabase.Gotrue.Responses;
 namespace Supabase.Gotrue
 {
 	/// <summary>
-	/// Utility methods to assist with flow. Includes nonce generation & verification.
+	/// Utility methods to assist with flow. Includes nonce generation and verification.
 	/// </summary>
 	public static class Helpers
 	{

--- a/Gotrue/Interfaces/IGotrueAdminClient.cs
+++ b/Gotrue/Interfaces/IGotrueAdminClient.cs
@@ -1,0 +1,84 @@
+using System.Threading.Tasks;
+using Supabase.Core.Interfaces;
+namespace Supabase.Gotrue.Interfaces
+{
+	/// <summary>
+	/// Interface for the Gotrue Admin Client (auth).
+	/// </summary>
+	/// <typeparam name="TUser"></typeparam>
+	public interface IGotrueAdminClient<TUser> : IGettableHeaders
+		where TUser : User
+	{
+		/// <summary>
+		/// Creates a user using the admin key (not the anonymous key).
+		/// Used in trusted server environments, not client apps.
+		/// </summary>
+		/// <param name="attributes"></param>
+		/// <returns></returns>
+		Task<TUser?> CreateUser(AdminUserAttributes attributes);
+
+		/// <summary>
+		/// Creates a user using the admin key (not the anonymous key).
+		/// Used in trusted server environments, not client apps.
+		/// </summary>
+		/// <param name="email"></param>
+		/// <param name="password"></param>
+		/// <param name="attributes"></param>
+		/// <returns></returns>
+		Task<TUser?> CreateUser(string email, string password, AdminUserAttributes? attributes = null);
+
+		/// <summary>
+		/// Creates a user using the admin key (not the anonymous key).
+		/// Used in trusted server environments, not client apps.
+		/// </summary>
+		Task<bool> DeleteUser(string uid);
+
+		/// <summary>
+		/// Gets a user from a user's JWT. This is using the GoTrue server to validate a user's JWT.
+		/// </summary>
+		/// <param name="jwt"></param>
+		/// <returns></returns>
+		Task<TUser?> GetUser(string jwt);
+		
+		/// <summary>
+		/// Gets a user by ID from the server using the admin key (not the anonymous key).
+		/// </summary>
+		/// <param name="userId"></param>
+		/// <returns></returns>
+		Task<TUser?> GetUserById(string userId);
+
+		/// <summary>
+		/// Sends an email to the user.
+		/// </summary>
+		/// <param name="email"></param>
+		/// <returns></returns>
+		Task<bool> InviteUserByEmail(string email);
+
+		/// <summary>
+		/// Lists users
+		/// </summary>
+		/// <param name="filter">A string for example part of the email</param>
+		/// <param name="sortBy">Snake case string of the given key, currently only created_at is supported</param>
+		/// <param name="sortOrder">asc or desc, if null desc is used</param>
+		/// <param name="page">page to show for pagination</param>
+		/// <param name="perPage">items per page for pagination</param>
+		/// <returns></returns>
+		Task<UserList<TUser>?> ListUsers(string? filter = null, string? sortBy = null, Constants.SortOrder sortOrder = Constants.SortOrder.Descending, int? page = null,
+			int? perPage = null);
+
+		/// <summary>
+		/// Updates a User using the service key
+		/// </summary>
+		/// <param name="attributes"></param>
+		/// <returns></returns>
+		public Task<User?> Update(UserAttributes attributes);
+		
+		/// <summary>
+		/// Update user by Id
+		/// </summary>
+		/// <param name="userId"></param>
+		/// <param name="userData"></param>
+		/// <returns></returns>
+		public Task<User?> UpdateUserById(string userId, AdminUserAttributes userData);
+	}
+}

--- a/Gotrue/Interfaces/IGotrueApi.cs
+++ b/Gotrue/Interfaces/IGotrueApi.cs
@@ -2,6 +2,7 @@
 using Supabase.Core.Interfaces;
 using Supabase.Gotrue.Responses;
 using static Supabase.Gotrue.Constants;
+#pragma warning disable CS1591
 
 namespace Supabase.Gotrue.Interfaces
 {

--- a/Gotrue/Interfaces/IGotrueClient.cs
+++ b/Gotrue/Interfaces/IGotrueClient.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Supabase.Core.Interfaces;
 using static Supabase.Gotrue.Constants;
+#pragma warning disable CS1591
 
 namespace Supabase.Gotrue.Interfaces
 {
@@ -67,29 +68,7 @@ namespace Supabase.Gotrue.Interfaces
 		/// <param name="stateChanged"></param>
 		void NotifyAuthStateChange(AuthState stateChanged);
 
-		/// <summary>
-		/// Creates a user using the admin key (not the anonymous key).
-		/// Used in trusted server environments, not client apps.
-		/// </summary>
-		/// <param name="jwt">Admin token</param>
-		/// <param name="attributes"></param>
-		/// <returns></returns>
-		Task<TUser?> CreateUser(string jwt, AdminUserAttributes attributes);
-		/// <summary>
-		/// Creates a user using the admin key (not the anonymous key).
-		/// Used in trusted server environments, not client apps.
-		/// </summary>
-		/// <param name="jwt">Admin Bearer token</param>
-		/// <param name="email"></param>
-		/// <param name="password"></param>
-		/// <param name="attributes"></param>
-		/// <returns></returns>
-		Task<TUser?> CreateUser(string jwt, string email, string password, AdminUserAttributes? attributes = null);
-		/// <summary>
-		/// Creates a user using the admin key (not the anonymous key).
-		/// Used in trusted server environments, not client apps.
-		/// </summary>
-		Task<bool> DeleteUser(string uid, string jwt);
+		
 		/// <summary>
 		/// Converts a URL to a session. For client apps, this probably requires setting up URL handlers.
 		/// </summary>
@@ -98,28 +77,8 @@ namespace Supabase.Gotrue.Interfaces
 		/// <returns></returns>
 		Task<TSession?> GetSessionFromUrl(Uri uri, bool storeSession = true);
 
-		/// <summary>
-		/// Gets a user from the JWT.
-		/// </summary>
-		/// <param name="jwt"></param>
-		/// <returns></returns>
-		Task<TUser?> GetUser(string jwt);
-		/// <summary>
-		/// Gets a user by ID from the server using the admin key (not the anonymous key).
-		/// </summary>
-		/// <param name="jwt"></param>
-		/// <param name="userId"></param>
-		/// <returns></returns>
-		Task<TUser?> GetUserById(string jwt, string userId);
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <param name="email"></param>
-		/// <param name="jwt"></param>
-		/// <returns></returns>
-		Task<bool> InviteUserByEmail(string email, string jwt);
-		Task<UserList<TUser>?> ListUsers(string jwt, string? filter = null, string? sortBy = null, SortOrder sortOrder = SortOrder.Descending, int? page = null,
-			int? perPage = null);
+	
+	
 		Task<TSession?> RefreshSession();
 		Task<bool> ResetPasswordForEmail(string email);
 		Task<TSession?> RetrieveSessionAsync();
@@ -139,7 +98,6 @@ namespace Supabase.Gotrue.Interfaces
 		Task<bool> Reauthenticate();
 		Task SignOut();
 		Task<TUser?> Update(UserAttributes attributes);
-		Task<TUser?> UpdateUserById(string jwt, string userId, AdminUserAttributes userData);
 		Task<TSession?> VerifyOTP(string phone, string token, MobileOtpType type = MobileOtpType.SMS);
 		Task<TSession?> VerifyOTP(string email, string token, EmailOtpType type = EmailOtpType.MagicLink);
 		/// <summary>
@@ -161,6 +119,13 @@ namespace Supabase.Gotrue.Interfaces
 		/// Returns the client options.
 		/// </summary>
 		ClientOptions Options { get; }
+		
+		/// <summary>
+		/// Gets a user from the JWT.
+		/// </summary>
+		/// <param name="jwt"></param>
+		/// <returns></returns>
+		Task<TUser?> GetUser(string jwt);
 
 	}
 }

--- a/Gotrue/Interfaces/IGotruePersistenceListener.cs
+++ b/Gotrue/Interfaces/IGotruePersistenceListener.cs
@@ -5,8 +5,16 @@ namespace Supabase.Gotrue.Interfaces
     /// </summary>
     public interface IGotruePersistenceListener<TSession> where TSession : Session
     {
+        /// <summary>
+        /// The persistence implementation for the client (e.g. file system, local storage, etc).
+        /// </summary>
         IGotrueSessionPersistence<TSession> Persistence { get; }
 
+        /// <summary>
+        /// Routes auth state changes to the persistence implementation.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="stateChanged"></param>
         public void EventHandler(IGotrueClient<User, TSession> sender, Constants.AuthState stateChanged);
     }
 }

--- a/Gotrue/Interfaces/IGotrueSessionPersistence.cs
+++ b/Gotrue/Interfaces/IGotrueSessionPersistence.cs
@@ -1,15 +1,28 @@
 namespace Supabase.Gotrue.Interfaces
 {
-    /// <summary>
-    /// Interface for session persistence. As a reminder, make sure you handle exceptions and
-    /// other error conditions in your implementation.
-    /// </summary>
-    public interface IGotrueSessionPersistence<TSession> where TSession : Session
-    {
-        public void SaveSession(TSession session);
+	/// <summary>
+	/// Interface for session persistence. As a reminder, make sure you handle exceptions and
+	/// other error conditions in your implementation.
+	/// </summary>
+	public interface IGotrueSessionPersistence<TSession>
+		where TSession : Session
+	{
+		/// <summary>
+		/// Saves the session to the persistence implementation.
+		/// </summary>
+		/// <param name="session"></param>
+		public void SaveSession(TSession session);
 
-        public void DestroySession();
+		/// <summary>
+		/// Destroys the session in the persistence implementation. Usually this means
+		/// deleting the session file or clearing local storage.
+		/// </summary>
+		public void DestroySession();
 
-        public TSession? LoadSession();
-    }
+		/// <summary>
+		/// Loads the session from the persistence implementation. Returns null if there is no session.
+		/// </summary>
+		/// <returns></returns>
+		public TSession? LoadSession();
+	}
 }

--- a/Gotrue/Interfaces/IGotrueStatelessClient.cs
+++ b/Gotrue/Interfaces/IGotrueStatelessClient.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using static Supabase.Gotrue.Constants;
 using static Supabase.Gotrue.StatelessClient;
+#pragma warning disable CS1591
 
 namespace Supabase.Gotrue.Interfaces
 {

--- a/Gotrue/NetworkStatus.cs
+++ b/Gotrue/NetworkStatus.cs
@@ -6,8 +6,10 @@ namespace Supabase.Gotrue
 {
 	/// <summary>
 	/// A Network status system to pair with the <see cref="Client.Online"/>Client.
-	///
-	/// <see cref="https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/network-info"/>
+	/// 
+	/// <see>
+	///     <cref>https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/network-info</cref>
+	/// </see>
 	/// </summary>
 	public class NetworkStatus
 	{

--- a/Gotrue/PersistenceListener.cs
+++ b/Gotrue/PersistenceListener.cs
@@ -18,6 +18,7 @@ namespace Supabase.Gotrue
 			Persistence = persistence;
 		}
 
+		/// <inheritdoc />
 		public IGotrueSessionPersistence<Session> Persistence { get; }
 
 		/// <summary>

--- a/Gotrue/Responses/BaseResponse.cs
+++ b/Gotrue/Responses/BaseResponse.cs
@@ -8,9 +8,15 @@ namespace Supabase.Gotrue.Responses
     /// </summary>
     public class BaseResponse
     {
+        /// <summary>
+        /// The HTTP response message.
+        /// </summary>
         [JsonIgnore]
         public HttpResponseMessage? ResponseMessage { get; set; }
 
+        /// <summary>
+        /// The HTTP response content as a string.
+        /// </summary>
         [JsonIgnore]
         public string? Content { get; set; }
     }

--- a/Gotrue/Session.cs
+++ b/Gotrue/Session.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Newtonsoft.Json;
+#pragma warning disable CS1591
 
 namespace Supabase.Gotrue
 {

--- a/Gotrue/Settings.cs
+++ b/Gotrue/Settings.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
+#pragma warning disable CS1591
 
 namespace Supabase.Gotrue
 {

--- a/Gotrue/SignInWithPasswordlessEmailOptions.cs
+++ b/Gotrue/SignInWithPasswordlessEmailOptions.cs
@@ -27,6 +27,7 @@ namespace Supabase.Gotrue
 		public bool ShouldCreateUser { get; set; } = true;
 	}
 
+	/// <inheritdoc />
 	public class SignInWithPasswordlessEmailOptions : SignInWithPasswordlessOptions
 	{
 		/// <summary>
@@ -53,6 +54,7 @@ namespace Supabase.Gotrue
 		}
 	}
 
+	/// <inheritdoc />
 	public class SignInWithPasswordlessPhoneOptions : SignInWithPasswordlessOptions
 	{
 		public enum MessagingChannel

--- a/Gotrue/User.cs
+++ b/Gotrue/User.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+#pragma warning disable CS1591
 
 namespace Supabase.Gotrue
 {

--- a/GotrueTests/ConfigurationFailureTests.cs
+++ b/GotrueTests/ConfigurationFailureTests.cs
@@ -36,12 +36,12 @@ namespace GotrueTests
 		[TestMethod("Bad service key message")]
 		public async Task BadServiceApiKeyTest()
 		{
-			IGotrueClient<User, Session> client = new Client(new ClientOptions { AllowUnconfirmedUserSessions = true });
-			client.AddDebugListener(LogDebug);
+			IGotrueAdminClient<User> adminClient = new AdminClient("bad_service_key", new ClientOptions { AllowUnconfirmedUserSessions = true });
+			AreEqual(true, ((AdminClient)adminClient).Options.AllowUnconfirmedUserSessions);
 
 			var x = await ThrowsExceptionAsync<GotrueException>(async () =>
 			{
-				await client.ListUsers("garbage key");
+				await adminClient.ListUsers();
 			});
 			AreEqual(AdminTokenRequired, x.Reason);
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Splits the stateful client into two classes. The methods requiring the service_key have been moved to a new AdminClient class.

Also some minor documentation tweaks/fixes, and also sets the language level to 9.0 instead of latest to help keep language level compatibility (useful e.g. if using the sources in Unity).

## What is the current behavior?

Right now the stateful client includes service_key methods. This doesn't really make a lot of sense, as the stateful client includes several features that don't make sense in a server environment (e.g. background refresh threads).

## What is the new behavior?

The only state the AdminClient really includes is the ServiceKey. It's a bit higher level than just using the StatelessClient directly.

This is a breaking change, as the interfaces and implementation have changed. The AdminClient methods do not take the service key JWT as parameters - typically that would be set in the constructor.

I suspect this doesn't really affect the top-level client all that much, as I hope that most, say, Xamarin users are not compiling in their service keys into their client apps. A user can use the AdminClient directly in their server-side code - this is probably more of a documentation thing.