### PR TITLE
Adds Shutdown. Moved docs to interfaces.

### DIFF
--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -11,20 +11,8 @@ using static Supabase.Gotrue.Exceptions.FailureHint.Reason;
 
 namespace Supabase.Gotrue
 {
-	/// <summary>
-	/// GoTrue stateful Client.
-	///
-	/// This class is best used as a long-lived singleton object in your application. You can attach listeners
-	/// to be notified of changes to the user log in state, a persistence system for sessions across application
-	/// launches, and more. It includes a (optional, on by default) background thread that runs to refresh the
-	/// user's session token.
-	///
-	/// Check out the test suite for examples of use.
-	/// </summary>
-	/// <example>
-	/// var client = new Supabase.Gotrue.Client(options);
-	/// var user = await client.SignIn("user@email.com", "fancyPassword");
-	/// </example>
+
+	/// <inheritdoc />
 	public class Client : IGotrueClient<User, Session>
 	{
 		/// <summary>
@@ -89,10 +77,7 @@ namespace Supabase.Gotrue
 			}
 		}
 
-		/// <summary>
-		/// Set the Session persistence system. Typically an application specific file system location.
-		/// </summary>
-		/// <param name="persistence"></param>
+		/// <inheritdoc />
 		public void SetPersistence(IGotrueSessionPersistence<Session> persistence)
 		{
 			if (_sessionPersistence != null) _authEventHandlers.Remove(_sessionPersistence.EventHandler);
@@ -100,25 +85,13 @@ namespace Supabase.Gotrue
 			_authEventHandlers.Add(_sessionPersistence.EventHandler);
 		}
 
-		/// <summary>
-		/// The initialized client options.
-		/// </summary>
+		/// <inheritdoc />
 		public ClientOptions Options { get; }
 
-		/// <summary>
-		/// Get User details by JWT. Can be used to validate a JWT.
-		/// </summary>
-		/// <param name="jwt">A valid JWT. Must be a JWT that originates from a user.</param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public Task<User?> GetUser(string jwt) => _api.GetUser(jwt);
 
-		
-		/// <summary>
-		/// Notifies all listeners that the current user auth state has changed.
-		///
-		/// This is mainly used internally to fire notifications - most client applications won't need this.
-		/// </summary>
-		/// <param name="stateChanged"></param>
+		/// <inheritdoc />
 		public void NotifyAuthStateChange(AuthState stateChanged)
 		{
 			foreach (var handler in _authEventHandlers)
@@ -134,20 +107,10 @@ namespace Supabase.Gotrue
 			}
 		}
 
-		/// <summary>
-		/// The currently logged in User. This is a local cache of the current session User. 
-		/// To persist modifications to the User you'll want to use other methods.
-		/// <see cref="Update"/>>
-		/// </summary>
+		/// <inheritdoc />
 		public User? CurrentUser { get => CurrentSession?.User; }
 
-		/// <summary>
-		/// Adds a listener to be notified when the user state changes (e.g. the user logs in, logs out,
-		/// the token is refreshed, etc).
-		///
-		/// <see cref="AuthState"/>
-		/// </summary>
-		/// <param name="authEventHandler"></param>
+		/// <inheritdoc />
 		public void AddStateChangedListener(IGotrueClient<User, Session>.AuthEventHandler authEventHandler)
 		{
 			if (_authEventHandlers.Contains(authEventHandler)) return;
@@ -155,10 +118,7 @@ namespace Supabase.Gotrue
 			_authEventHandlers.Add(authEventHandler);
 		}
 
-		/// <summary>
-		/// Removes a specified listener from event state changes.
-		/// </summary>
-		/// <param name="authEventHandler"></param>
+		/// <inheritdoc />
 		public void RemoveStateChangedListener(IGotrueClient<User, Session>.AuthEventHandler authEventHandler)
 		{
 			if (!_authEventHandlers.Contains(authEventHandler)) return;
@@ -166,12 +126,8 @@ namespace Supabase.Gotrue
 			_authEventHandlers.Remove(authEventHandler);
 		}
 
-		/// <summary>
-		/// Clears all of the listeners from receiving event state changes.
-		///
-		/// WARNING: The persistence handler and refresh token thread are installed as state change
-		/// listeners. Clearing the listeners will also delete these handlers.
-		/// </summary>
+
+		/// <inheritdoc />
 		public void ClearStateChangedListeners()
 		{
 			_authEventHandlers.Clear();
@@ -180,58 +136,15 @@ namespace Supabase.Gotrue
 		/// <inheritdoc />
 		public bool Online { get; set; } = true;
 
-		/// <summary>
-		/// The current Session as managed by this client. Does not refresh tokens or have any other side effects.
-		///
-		/// You probably don't want to directly make changes to this object - you'll want to use other methods
-		/// on this class to make changes.
-		/// </summary>
+		/// <inheritdoc />
 		public Session? CurrentSession { get; private set; }
 
-		/// <summary>
-		/// Signs up a user by email address.
-		/// </summary>
-		/// <remarks>
-		/// By default, the user needs to verify their email address before logging in. To turn this off, disable Confirm email in your project.
-		/// Confirm email determines if users need to confirm their email address after signing up.
-		///     - If Confirm email is enabled, a user is returned but session is null.
-		///     - If Confirm email is disabled, both a user and a session are returned.
-		/// When the user confirms their email address, they are redirected to the SITE_URL by default. You can modify your SITE_URL or
-		/// add additional redirect URLs in your project.
-		/// If signUp() is called for an existing confirmed user:
-		///     - If Confirm email is enabled in your project, an obfuscated/fake user object is returned.
-		///     - If Confirm email is disabled, the error message, User already registered is returned.
-		/// To fetch the currently logged-in user, refer to <see>
-		///     <cref>User</cref>
-		/// </see>.
-		/// </remarks>
-		/// <param name="email"></param>
-		/// <param name="password"></param>
-		/// <param name="options">Object containing redirectTo and optional user metadata (data)</param>
-		/// <returns></returns>
+
+		/// <inheritdoc />
 		public Task<Session?> SignUp(string email, string password, SignUpOptions? options = null) => SignUp(SignUpType.Email, email, password, options);
 
-		/// <summary>
-		/// Signs up a user
-		/// </summary>
-		/// <remarks>
-		/// Calling this method will log out the current user session (if any).
-		/// 
-		/// By default, the user needs to verify their email address before logging in. To turn this off, disable confirm email in your project.
-		/// Confirm email determines if users need to confirm their email address after signing up.
-		///     - If Confirm email is enabled, a user is returned but session is null.
-		///     - If Confirm email is disabled, both a user and a session are returned.
-		/// When the user confirms their email address, they are redirected to the SITE_URL by default. You can modify your SITE_URL or add additional redirect URLs in your project.
-		/// If signUp() is called for an existing confirmed user:
-		///     - If Confirm email is enabled in your project, an obfuscated/fake user object is returned.
-		///     - If Confirm email is disabled, the error message, User already registered is returned.
-		/// To fetch the currently logged-in user, refer to <see cref="User"/>.
-		/// </remarks>
-		/// <param name="type"></param>
-		/// <param name="identifier"></param>
-		/// <param name="password"></param>
-		/// <param name="options">Object containing redirectTo and optional user metadata (data)</param>
-		/// <returns></returns>
+
+		/// <inheritdoc />
 		public async Task<Session?> SignUp(SignUpType type, string identifier, string password, SignUpOptions? options = null)
 		{
 			if (!Online)
@@ -256,12 +169,7 @@ namespace Supabase.Gotrue
 			return session;
 		}
 
-
-		/// <summary>
-		/// Sends a magic link login email to the specified email.
-		/// </summary>
-		/// <param name="email"></param>
-		/// <param name="options"></param>
+		/// <inheritdoc />
 		public async Task<bool> SignIn(string email, SignInOptions? options = null)
 		{
 			if (!Online)
@@ -271,19 +179,7 @@ namespace Supabase.Gotrue
 			return true;
 		}
 
-		/// <summary>
-		/// Allows signing in with an ID token issued by certain supported providers.
-		/// The [idToken] is verified for validity and a new session is established.
-		/// This method of signing in only supports [Provider.Google] or [Provider.Apple].
-		/// </summary>
-		/// <param name="provider">A supported provider (Google, Apple)</param>
-		/// <param name="idToken">Provided from External Library</param>
-		/// <param name="nonce">Provided from External Library</param>
-		/// <param name="captchaToken">Provided from External Library</param>
-		/// <remarks>Calling this method will eliminate the current session (if any).</remarks>
-		/// <exception>
-		///     <cref>InvalidProviderException</cref>
-		/// </exception>
+		/// <inheritdoc />
 		public async Task<Session?> SignInWithIdToken(Provider provider, string idToken, string? nonce = null, string? captchaToken = null)
 		{
 			if (!Online)
@@ -297,24 +193,8 @@ namespace Supabase.Gotrue
 			return result;
 		}
 
-		/// <summary>
-		/// Log in a user using magiclink or a one-time password (OTP).
-		/// 
-		/// If the `{{ .ConfirmationURL }}` variable is specified in the email template, a magiclink will be sent.
-		/// If the `{{ .Token }}` variable is specified in the email template, an OTP will be sent.
-		/// If you're using phone sign-ins, only an OTP will be sent. You won't be able to send a magiclink for phone sign-ins.
-		/// 
-		/// Be aware that you may get back an error message that will not distinguish
-		/// between the cases where the account does not exist or, that the account
-		/// can only be accessed via social login.
-		/// 
-		/// Do note that you will need to configure a Whatsapp sender on Twilio
-		/// if you are using phone sign in with the 'whatsapp' channel. The whatsapp
-		/// channel is not supported on other providers at this time.
-		/// </summary>
-		/// <remarks>Calling this method will wipe out the current session (if any)</remarks>
-		/// <param name="options"></param>
-		/// <returns></returns>
+
+		/// <inheritdoc />
 		public async Task<PasswordlessSignInState> SignInWithOtp(SignInWithPasswordlessEmailOptions options)
 		{
 			if (!Online)
@@ -324,24 +204,8 @@ namespace Supabase.Gotrue
 			return await _api.SignInWithOtp(options);
 		}
 
-		/// <summary>
-		/// Log in a user using magiclink or a one-time password (OTP).
-		/// 
-		/// If the `{{ .ConfirmationURL }}` variable is specified in the email template, a magiclink will be sent.
-		/// If the `{{ .Token }}` variable is specified in the email template, an OTP will be sent.
-		/// If you're using phone sign-ins, only an OTP will be sent. You won't be able to send a magiclink for phone sign-ins.
-		/// 
-		/// Be aware that you may get back an error message that will not distinguish
-		/// between the cases where the account does not exist or, that the account
-		/// can only be accessed via social login.
-		/// 
-		/// Do note that you will need to configure a Whatsapp sender on Twilio
-		/// if you are using phone sign in with the 'whatsapp' channel. The whatsapp
-		/// channel is not supported on other providers at this time.
-		/// </summary>
-		/// <remarks>Calling this method will wipe out the current session (if any)</remarks>
-		/// <param name="options"></param>
-		/// <returns></returns>
+
+		/// <inheritdoc />
 		public async Task<PasswordlessSignInState> SignInWithOtp(SignInWithPasswordlessPhoneOptions options)
 		{
 			if (!Online)
@@ -351,38 +215,18 @@ namespace Supabase.Gotrue
 			return await _api.SignInWithOtp(options);
 		}
 
-		/// <summary>
-		/// Sends a Magic email login link to the specified email.
-		/// </summary>
-		/// <param name="email"></param>
-		/// <param name="options"></param>
-		/// <returns></returns>
+
+		/// <inheritdoc />
 		public Task<bool> SendMagicLink(string email, SignInOptions? options = null) => SignIn(email, options);
 
-		/// <summary>
-		/// Signs in a User.
-		/// </summary>
-		/// <param name="email"></param>
-		/// <param name="password"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public Task<Session?> SignIn(string email, string password) => SignIn(SignInType.Email, email, password);
 
-		/// <summary>
-		/// Log in an existing user with an email and password or phone and password.
-		/// </summary>
-		/// <param name="email"></param>
-		/// <param name="password"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public Task<Session?> SignInWithPassword(string email, string password) => SignIn(email, password);
 
-		/// <summary>
-		/// Log in an existing user, or login via a third-party provider.
-		/// </summary>
-		/// <param name="type">Type of Credentials being passed</param>
-		/// <param name="identifierOrToken">An email, phone, or RefreshToken</param>
-		/// <param name="password">Password to account (optional if `RefreshToken`)</param>
-		/// <param name="scopes">A space-separated list of scopes granted to the OAuth application.</param>
-		/// <returns></returns>
+
+		/// <inheritdoc />
 		public async Task<Session?> SignIn(SignInType type, string identifierOrToken, string? password = null, string? scopes = null)
 		{
 			if (!Online)
@@ -420,15 +264,8 @@ namespace Supabase.Gotrue
 			return null;
 		}
 
-		/// <summary>
-		/// Retrieves a <see cref="ProviderAuthState"/> to redirect to for signing in with a <see cref="Provider"/>.
-		///
-		/// This will likely be paired with a PKCE flow (set in SignInOptions) - after redirecting the
-		/// user to the flow, you should pair with <see cref="ExchangeCodeForSession(string, string)"/>
-		/// </summary>
-		/// <param name="provider"></param>
-		/// <param name="options"></param>
-		/// <returns></returns>
+
+		/// <inheritdoc />
 		public Task<ProviderAuthState> SignIn(Provider provider, SignInOptions? options = null)
 		{
 			if (!Online)
@@ -440,13 +277,8 @@ namespace Supabase.Gotrue
 			return Task.FromResult(providerUri);
 		}
 
-		/// <summary>
-		/// Log in a user given a User supplied OTP received via mobile.
-		/// </summary>
-		/// <param name="phone">The user's phone number.</param>
-		/// <param name="token">Token sent to the user's phone.</param>
-		/// <param name="type">SMS or phone change</param>
-		/// <returns></returns>
+
+		/// <inheritdoc />
 		public async Task<Session?> VerifyOTP(string phone, string token, MobileOtpType type = MobileOtpType.SMS)
 		{
 			if (!Online)
@@ -466,13 +298,8 @@ namespace Supabase.Gotrue
 			return null;
 		}
 
-		/// <summary>
-		/// Log in a user give a user supplied OTP received via email.
-		/// </summary>
-		/// <param name="email"></param>
-		/// <param name="token"></param>
-		/// <param name="type">Defaults to MagicLink</param>
-		/// <returns></returns>
+
+		/// <inheritdoc />
 		public async Task<Session?> VerifyOTP(string email, string token, EmailOtpType type = EmailOtpType.MagicLink)
 		{
 			if (!Online)
@@ -492,10 +319,8 @@ namespace Supabase.Gotrue
 			return null;
 		}
 
-		/// <summary>
-		/// Signs out a user and invalidates the current token.
-		/// </summary>
-		/// <returns></returns>
+
+		/// <inheritdoc />
 		public async Task SignOut()
 		{
 			if (CurrentSession?.AccessToken != null) await _api.SignOut(CurrentSession.AccessToken);
@@ -503,11 +328,8 @@ namespace Supabase.Gotrue
 			NotifyAuthStateChange(SignedOut);
 		}
 
-		/// <summary>
-		/// Updates a User.
-		/// </summary>
-		/// <param name="attributes"></param>
-		/// <returns></returns>
+
+		/// <inheritdoc />
 		public async Task<User?> Update(UserAttributes attributes)
 		{
 			if (CurrentSession == null || string.IsNullOrEmpty(CurrentSession.AccessToken))
@@ -523,13 +345,8 @@ namespace Supabase.Gotrue
 			return result;
 		}
 
-		/// <summary>
-		/// Used for re-authenticating a user in password changes.
-		///
-		/// See: https://github.com/supabase/gotrue#get-reauthenticate
-		/// </summary>
-		/// <returns></returns>
-		/// <exception cref="GotrueException"></exception>
+
+		/// <inheritdoc />
 		public async Task<bool> Reauthenticate()
 		{
 			if (CurrentSession == null || string.IsNullOrEmpty(CurrentSession.AccessToken))
@@ -543,13 +360,7 @@ namespace Supabase.Gotrue
 			return response.ResponseMessage?.IsSuccessStatusCode ?? false;
 		}
 
-	
-		
-		/// <summary>
-		/// Sends a reset request to an email address.
-		/// </summary>
-		/// <param name="email"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public async Task<bool> ResetPasswordForEmail(string email)
 		{
 			var result = await _api.ResetPasswordForEmail(email);
@@ -557,10 +368,7 @@ namespace Supabase.Gotrue
 			return true;
 		}
 
-		/// <summary>
-		/// Refreshes the currently logged in User's Session.
-		/// </summary>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public async Task<Session?> RefreshSession()
 		{
 			if (CurrentSession == null || string.IsNullOrEmpty(CurrentSession.AccessToken))
@@ -577,11 +385,7 @@ namespace Supabase.Gotrue
 			return CurrentSession;
 		}
 
-		/// <summary>
-		///  Overrides the JWT on the current session. The JWT will then be sent in all subsequent network requests.
-		/// </summary>
-		/// <param name="accessToken">The JWT access token.</param>
-		/// <returns>Session.</returns>
+		/// <inheritdoc />
 		public Session SetAuth(string accessToken)
 		{
 			CurrentSession ??= new Session();
@@ -648,13 +452,8 @@ namespace Supabase.Gotrue
 			return session;
 		}
 
-		/// <summary>
-		/// Retrieves the Session by calling <see>
-		///     <cref>SessionRetriever</cref>
-		/// </see>
-		/// - sets internal state and timers.
-		/// </summary>
-		/// <returns></returns>
+
+		/// <inheritdoc />
 		public async Task<Session?> RetrieveSessionAsync()
 		{
 			// No session, so just return.
@@ -695,11 +494,8 @@ namespace Supabase.Gotrue
 			return CurrentSession;
 		}
 
-		/// <summary>
-		/// Logs in an existing user via a third-party provider.
-		/// </summary>
-		/// <param name="codeVerifier"></param>
-		/// <param name="authCode"></param>
+
+		/// <inheritdoc />
 		public async Task<Session?> ExchangeCodeForSession(string codeVerifier, string authCode)
 		{
 			var result = await _api.ExchangeCodeForSession(codeVerifier, authCode);
@@ -723,12 +519,8 @@ namespace Supabase.Gotrue
 			set => _api.GetHeaders = value;
 		}
 
-		/// <summary>
-		/// Add a listener to get errors that occur outside of a typical Exception flow.
-		/// In particular, this is used to get errors and messages from the background thread
-		/// that automatically manages refreshing the user's token.
-		/// </summary>
-		/// <param name="listener"></param>
+
+		/// <inheritdoc />
 		public void AddDebugListener(Action<string, Exception?> listener)
 		{
 			_debugNotification ??= new DebugNotification();
@@ -804,18 +596,15 @@ namespace Supabase.Gotrue
 			NotifyAuthStateChange(TokenRefreshed);
 		}
 
-		/// <summary>
-		/// Loads the session from the persistence provider
-		/// </summary>
+
+		/// <inheritdoc />
 		public void LoadSession()
 		{
 			if (_sessionPersistence != null) UpdateSession(_sessionPersistence.Persistence.LoadSession());
 		}
 
-		/// <summary>
-		/// Retrieves the settings from the server
-		/// </summary>
-		/// <returns></returns>
+
+		/// <inheritdoc />
 		public Task<Settings?> Settings()
 		{
 			// if(!Online)
@@ -823,15 +612,16 @@ namespace Supabase.Gotrue
 			return _api.Settings();
 		}
 
-		/// <summary>
-		/// Posts messages and exceptions to the debug listener. This is particularly useful for sorting
-		/// out issues with the refresh token background thread.
-		/// </summary>
-		/// <param name="message"></param>
-		/// <param name="e"></param>
+		/// <inheritdoc />
 		public void Debug(string message, Exception? e = null)
 		{
 			_debugNotification?.Log(message, e);
+		}
+
+		/// <inheritdoc />
+		public void Shutdown()
+		{
+			NotifyAuthStateChange(AuthState.Shutdown);
 		}
 	}
 }

--- a/Gotrue/Constants.cs
+++ b/Gotrue/Constants.cs
@@ -103,7 +103,8 @@ namespace Supabase.Gotrue
             SignedOut,
             UserUpdated,
             PasswordRecovery,
-            TokenRefreshed
+            TokenRefreshed,
+            Shutdown
         }
 
         /// <summary>

--- a/Gotrue/DebugNotification.cs
+++ b/Gotrue/DebugNotification.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-
 namespace Supabase.Gotrue
 {
 	/// <summary>

--- a/Gotrue/Exceptions/GotrueException.cs
+++ b/Gotrue/Exceptions/GotrueException.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Net.Http;
-
 namespace Supabase.Gotrue.Exceptions
 {
 	/// <summary>

--- a/Gotrue/Helpers.cs
+++ b/Gotrue/Helpers.cs
@@ -9,7 +9,6 @@ using System.Web;
 using Newtonsoft.Json;
 using Supabase.Gotrue.Exceptions;
 using Supabase.Gotrue.Responses;
-
 namespace Supabase.Gotrue
 {
 	/// <summary>

--- a/Gotrue/Interfaces/IGotrueClient.cs
+++ b/Gotrue/Interfaces/IGotrueClient.cs
@@ -1,18 +1,26 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Supabase.Core.Interfaces;
+using Supabase.Gotrue.Exceptions;
 using static Supabase.Gotrue.Constants;
 #pragma warning disable CS1591
 
 namespace Supabase.Gotrue.Interfaces
 {
 	/// <summary>
-	/// Interface for the Gotrue Client (auth).
+	/// GoTrue stateful Client.
 	///
-	/// For more information check out the <see cref="Client"/> implementation.
+	/// This class is best used as a long-lived singleton object in your application. You can attach listeners
+	/// to be notified of changes to the user log in state, a persistence system for sessions across application
+	/// launches, and more. It includes a (optional, on by default) background thread that runs to refresh the
+	/// user's session token.
+	///
+	/// Check out the test suite for examples of use.
 	/// </summary>
-	/// <typeparam name="TUser"></typeparam>
-	/// <typeparam name="TSession"></typeparam>
+	/// <example>
+	/// var client = new Supabase.Gotrue.Client(options);
+	/// var user = await client.SignIn("user@email.com", "fancyPassword");
+	/// </example>
 	public interface IGotrueClient<TUser, TSession> : IGettableHeaders
 		where TUser : User
 		where TSession : Session
@@ -28,12 +36,17 @@ namespace Supabase.Gotrue.Interfaces
 		bool Online { get; set; }
 
 		/// <summary>
-		/// The current in-memory session.
+		/// The current Session as managed by this client. Does not refresh tokens or have any other side effects.
+		///
+		/// You probably don't want to directly make changes to this object - you'll want to use other methods
+		/// on this class to make changes.
 		/// </summary>
 		TSession? CurrentSession { get; }
 
 		/// <summary>
-		/// The current in-memory user.
+		/// The currently logged in User. This is a local cache of the current session User. 
+		/// To persist modifications to the User you'll want to use other methods.
+		/// <see cref="Update"/>>
 		/// </summary>
 		TUser? CurrentUser { get; }
 
@@ -49,26 +62,37 @@ namespace Supabase.Gotrue.Interfaces
 		void SetPersistence(IGotrueSessionPersistence<TSession> persistence);
 
 		/// <summary>
-		/// Adds a listener for the user state change event.
+		/// Adds a listener to be notified when the user state changes (e.g. the user logs in, logs out,
+		/// the token is refreshed, etc).
+		///
+		/// <see cref="AuthState"/>
 		/// </summary>
 		/// <param name="authEventHandler"></param>
 		void AddStateChangedListener(AuthEventHandler authEventHandler);
+
 		/// <summary>
-		/// Removes a listener for the user state change event.
+		/// Removes a specified listener from event state changes.
 		/// </summary>
 		/// <param name="authEventHandler"></param>
 		void RemoveStateChangedListener(AuthEventHandler authEventHandler);
+
 		/// <summary>
-		/// Removes all listeners for the user state change event - including the persistence listener.
+		/// Clears all of the listeners from receiving event state changes.
+		///
+		/// WARNING: The persistence handler and refresh token thread are installed as state change
+		/// listeners. Clearing the listeners will also delete these handlers.
 		/// </summary>
 		void ClearStateChangedListeners();
+
 		/// <summary>
-		/// Notifies all listeners of a user state change. This is called internally by the client.
+		/// Notifies all listeners that the current user auth state has changed.
+		///
+		/// This is mainly used internally to fire notifications - most client applications won't need this.
 		/// </summary>
 		/// <param name="stateChanged"></param>
 		void NotifyAuthStateChange(AuthState stateChanged);
 
-		
+
 		/// <summary>
 		/// Converts a URL to a session. For client apps, this probably requires setting up URL handlers.
 		/// </summary>
@@ -77,40 +101,256 @@ namespace Supabase.Gotrue.Interfaces
 		/// <returns></returns>
 		Task<TSession?> GetSessionFromUrl(Uri uri, bool storeSession = true);
 
-	
-	
-		Task<TSession?> RefreshSession();
-		Task<bool> ResetPasswordForEmail(string email);
-		Task<TSession?> RetrieveSessionAsync();
-		Task<bool> SendMagicLink(string email, SignInOptions? options = null);
-		TSession SetAuth(string accessToken);
-		Task<TSession?> SignIn(SignInType type, string identifierOrToken, string? password = null, string? scopes = null);
-		Task<bool> SignIn(string email, SignInOptions? options = null);
-		Task<TSession?> SignIn(string email, string password);
-		Task<PasswordlessSignInState> SignInWithOtp(SignInWithPasswordlessEmailOptions options);
-		Task<PasswordlessSignInState> SignInWithOtp(SignInWithPasswordlessPhoneOptions options);
-		Task<TSession?> SignInWithPassword(string email, string password);
-		Task<ProviderAuthState> SignIn(Provider provider, SignInOptions? options = null);
-		Task<TSession?> SignInWithIdToken(Provider provider, string idToken, string? nonce = null, string? captchaToken = null);
-		Task<TSession?> ExchangeCodeForSession(string codeVerifier, string authCode);
-		Task<TSession?> SignUp(SignUpType type, string identifier, string password, SignUpOptions? options = null);
-		Task<TSession?> SignUp(string email, string password, SignUpOptions? options = null);
-		Task<bool> Reauthenticate();
-		Task SignOut();
-		Task<TUser?> Update(UserAttributes attributes);
-		Task<TSession?> VerifyOTP(string phone, string token, MobileOtpType type = MobileOtpType.SMS);
-		Task<TSession?> VerifyOTP(string email, string token, EmailOtpType type = EmailOtpType.MagicLink);
 		/// <summary>
-		/// Adds a listener for debug messages (e.g. background threads).
+		/// Refreshes the currently logged in User's Session.
 		/// </summary>
-		/// <param name="logDebug"></param>
-		void AddDebugListener(Action<string, Exception?> logDebug);
+		/// <returns></returns>
+		Task<TSession?> RefreshSession();
+
+		/// <summary>
+		/// Sends a reset request to an email address.
+		/// </summary>
+		/// <param name="email"></param>
+		/// <returns></returns>
+		Task<bool> ResetPasswordForEmail(string email);
+
+		/// <summary>
+		/// Typically called as part of the startup process for the client.
+		///
+		/// This will take the currently loaded session (e.g. from a persistence implementation) and
+		/// if possible attempt to refresh it. If the loaded session is expired or invalid, it will
+		/// log the user out.
+		/// </summary>
+		/// <returns></returns>
+		Task<TSession?> RetrieveSessionAsync();
+
+		/// <summary>
+		/// Sends a Magic email login link to the specified email.
+		///
+		/// Most of the interesting configuration for this flow is done in the
+		/// Supabase/GoTrue admin panel.
+		/// 
+		/// </summary>
+		/// <param name="email"></param>
+		/// <param name="options"></param>
+		/// <returns></returns>
+		Task<bool> SendMagicLink(string email, SignInOptions? options = null);
+
+		/// <summary>
+		///  Overrides the JWT access token for the current session. The access token will
+		/// then be sent in all subsequent network requests.
+		/// </summary>
+		/// <param name="accessToken">The JWT access token.</param>
+		/// <returns>Session.</returns>
+		TSession SetAuth(string accessToken);
+
+		/// <summary>
+		/// Log in an existing user, or login via a third-party provider.
+		/// </summary>
+		/// <param name="type">Type of Credentials being passed</param>
+		/// <param name="identifierOrToken">An email, phone, or RefreshToken</param>
+		/// <param name="password">Password to account (optional if `RefreshToken`)</param>
+		/// <param name="scopes">A space-separated list of scopes granted to the OAuth application.</param>
+		/// <returns></returns>
+		Task<TSession?> SignIn(SignInType type, string identifierOrToken, string? password = null, string? scopes = null);
+
+		/// <summary>
+		/// Sends a magic link login email to the specified email.
+		/// </summary>
+		/// <param name="email"></param>
+		/// <param name="options"></param>
+		Task<bool> SignIn(string email, SignInOptions? options = null);
+
+		/// <summary>
+		/// Signs in a User.
+		/// </summary>
+		/// <param name="email"></param>
+		/// <param name="password"></param>
+		/// <returns></returns>
+		Task<TSession?> SignIn(string email, string password);
+
+		/// <summary>
+		/// Log in a user using magiclink or a one-time password (OTP).
+		/// 
+		/// If the `{{ .ConfirmationURL }}` variable is specified in the email template, a magiclink will be sent.
+		/// If the `{{ .Token }}` variable is specified in the email template, an OTP will be sent.
+		/// If you're using phone sign-ins, only an OTP will be sent. You won't be able to send a magiclink for phone sign-ins.
+		/// 
+		/// Be aware that you may get back an error message that will not distinguish
+		/// between the cases where the account does not exist or, that the account
+		/// can only be accessed via social login.
+		/// 
+		/// Do note that you will need to configure a Whatsapp sender on Twilio
+		/// if you are using phone sign in with the 'whatsapp' channel. The whatsapp
+		/// channel is not supported on other providers at this time.
+		/// </summary>
+		/// <remarks>Calling this method will wipe out the current session (if any)</remarks>
+		/// <param name="options"></param>
+		/// <returns></returns>
+		Task<PasswordlessSignInState> SignInWithOtp(SignInWithPasswordlessEmailOptions options);
+
+		/// <summary>
+		/// Log in a user using magiclink or a one-time password (OTP).
+		/// 
+		/// If the `{{ .ConfirmationURL }}` variable is specified in the email template, a magiclink will be sent.
+		/// If the `{{ .Token }}` variable is specified in the email template, an OTP will be sent.
+		/// If you're using phone sign-ins, only an OTP will be sent. You won't be able to send a magiclink for phone sign-ins.
+		/// 
+		/// Be aware that you may get back an error message that will not distinguish
+		/// between the cases where the account does not exist or, that the account
+		/// can only be accessed via social login.
+		/// 
+		/// Do note that you will need to configure a Whatsapp sender on Twilio
+		/// if you are using phone sign in with the 'whatsapp' channel. The whatsapp
+		/// channel is not supported on other providers at this time.
+		/// </summary>
+		/// <remarks>Calling this method will wipe out the current session (if any)</remarks>
+		/// <param name="options"></param>
+		/// <returns></returns>
+		Task<PasswordlessSignInState> SignInWithOtp(SignInWithPasswordlessPhoneOptions options);
+
+		/// <summary>
+		/// Log in an existing user with an email and password or phone and password.
+		/// </summary>
+		/// <param name="email"></param>
+		/// <param name="password"></param>
+		/// <returns></returns>
+		Task<TSession?> SignInWithPassword(string email, string password);
+
+		/// <summary>
+		/// Retrieves a <see cref="ProviderAuthState"/> to redirect to for signing in with a <see cref="Provider"/>.
+		///
+		/// This will likely be paired with a PKCE flow (set in SignInOptions) - after redirecting the
+		/// user to the flow, you should pair with <see cref="ExchangeCodeForSession(string, string)"/>
+		/// </summary>
+		/// <param name="provider"></param>
+		/// <param name="options"></param>
+		/// <returns></returns>
+		Task<ProviderAuthState> SignIn(Provider provider, SignInOptions? options = null);
+
+		/// <summary>
+		/// Allows signing in with an ID token issued by certain supported providers.
+		/// The [idToken] is verified for validity and a new session is established.
+		/// This method of signing in only supports [Provider.Google] or [Provider.Apple].
+		/// </summary>
+		/// <param name="provider">A supported provider (Google, Apple)</param>
+		/// <param name="idToken">Provided from External Library</param>
+		/// <param name="nonce">Provided from External Library</param>
+		/// <param name="captchaToken">Provided from External Library</param>
+		/// <remarks>Calling this method will eliminate the current session (if any).</remarks>
+		/// <exception>
+		///     <cref>InvalidProviderException</cref>
+		/// </exception>
+		Task<TSession?> SignInWithIdToken(Provider provider, string idToken, string? nonce = null, string? captchaToken = null);
+
+		/// <summary>
+		/// Logs in an existing user via a third-party provider.
+		/// </summary>
+		/// <param name="codeVerifier"></param>
+		/// <param name="authCode"></param>
+		Task<TSession?> ExchangeCodeForSession(string codeVerifier, string authCode);
+
+		/// <summary>
+		/// Signs up a user
+		/// </summary>
+		/// <remarks>
+		/// Calling this method will log out the current user session (if any).
+		/// 
+		/// By default, the user needs to verify their email address before logging in. To turn this off, disable confirm email in your project.
+		/// Confirm email determines if users need to confirm their email address after signing up.
+		///     - If Confirm email is enabled, a user is returned but session is null.
+		///     - If Confirm email is disabled, both a user and a session are returned.
+		/// When the user confirms their email address, they are redirected to the SITE_URL by default. You can modify your SITE_URL or add additional redirect URLs in your project.
+		/// If signUp() is called for an existing confirmed user:
+		///     - If Confirm email is enabled in your project, an obfuscated/fake user object is returned.
+		///     - If Confirm email is disabled, the error message, User already registered is returned.
+		/// To fetch the currently logged-in user, refer to <see cref="User"/>.
+		/// </remarks>
+		/// <param name="type"></param>
+		/// <param name="identifier"></param>
+		/// <param name="password"></param>
+		/// <param name="options">Object containing redirectTo and optional user metadata (data)</param>
+		/// <returns></returns>
+		Task<TSession?> SignUp(SignUpType type, string identifier, string password, SignUpOptions? options = null);
+
+		/// <summary>
+		/// Signs up a user by email address.
+		/// </summary>
+		/// <remarks>
+		/// By default, the user needs to verify their email address before logging in. To turn this off, disable Confirm email in your project.
+		/// Confirm email determines if users need to confirm their email address after signing up.
+		///     - If Confirm email is enabled, a user is returned but session is null.
+		///     - If Confirm email is disabled, both a user and a session are returned.
+		/// When the user confirms their email address, they are redirected to the SITE_URL by default. You can modify your SITE_URL or
+		/// add additional redirect URLs in your project.
+		/// If signUp() is called for an existing confirmed user:
+		///     - If Confirm email is enabled in your project, an obfuscated/fake user object is returned.
+		///     - If Confirm email is disabled, the error message, User already registered is returned.
+		/// To fetch the currently logged-in user, refer to <see>
+		///     <cref>User</cref>
+		/// </see>.
+		/// </remarks>
+		/// <param name="email"></param>
+		/// <param name="password"></param>
+		/// <param name="options">Object containing redirectTo and optional user metadata (data)</param>
+		/// <returns></returns>
+		Task<TSession?> SignUp(string email, string password, SignUpOptions? options = null);
+
+		/// <summary>
+		/// Used for re-authenticating a user in password changes.
+		///
+		/// See: https://github.com/supabase/gotrue#get-reauthenticate
+		/// </summary>
+		/// <returns></returns>
+		/// <exception cref="GotrueException"></exception>
+		Task<bool> Reauthenticate();
+
+		/// <summary>
+		/// Signs out a user and invalidates the current token.
+		/// </summary>
+		/// <returns></returns>
+		Task SignOut();
+
+		/// <summary>
+		/// Updates a User.
+		/// </summary>
+		/// <param name="attributes"></param>
+		/// <returns></returns>
+		Task<TUser?> Update(UserAttributes attributes);
+
+		/// <summary>
+		/// Log in a user given a User supplied OTP received via mobile.
+		/// </summary>
+		/// <param name="phone">The user's phone number.</param>
+		/// <param name="token">Token sent to the user's phone.</param>
+		/// <param name="type">SMS or phone change</param>
+		/// <returns></returns>
+		Task<TSession?> VerifyOTP(string phone, string token, MobileOtpType type = MobileOtpType.SMS);
+
+		/// <summary>
+		/// Log in a user give a user supplied OTP received via email.
+		/// </summary>
+		/// <param name="email"></param>
+		/// <param name="token"></param>
+		/// <param name="type">Defaults to MagicLink</param>
+		/// <returns></returns>
+		Task<TSession?> VerifyOTP(string email, string token, EmailOtpType type = EmailOtpType.MagicLink);
+
+		/// <summary>
+		/// Add a listener to get errors that occur outside of a typical Exception flow.
+		/// In particular, this is used to get errors and messages from the background thread
+		/// that automatically manages refreshing the user's token.
+		/// </summary>
+		/// <param name="listener">Callback method for debug messages</param>
+		void AddDebugListener(Action<string, Exception?> listener);
+
 		/// <summary>
 		/// Loads the session from the persistence layer.
 		/// </summary>
 		void LoadSession();
+		
 		/// <summary>
-		/// Fetch the server options.
+		/// Retrieves the settings from the server
 		/// </summary>
 		/// <returns></returns>
 		Task<Settings?> Settings();
@@ -119,13 +359,27 @@ namespace Supabase.Gotrue.Interfaces
 		/// Returns the client options.
 		/// </summary>
 		ClientOptions Options { get; }
-		
+
 		/// <summary>
-		/// Gets a user from the JWT.
+		/// Get User details by JWT. Can be used to validate a JWT.
 		/// </summary>
-		/// <param name="jwt"></param>
+		/// <param name="jwt">A valid JWT. Must be a JWT that originates from a user.</param>
 		/// <returns></returns>
 		Task<TUser?> GetUser(string jwt);
 
+		/// <summary>
+		/// Posts messages and exceptions to the debug listener. This is particularly useful for sorting
+		/// out issues with the refresh token background thread.
+		/// </summary>
+		/// <param name="message"></param>
+		/// <param name="e"></param>
+		void Debug(string message, Exception? e = null);
+		
+		/// <summary>
+		/// Let all of the listeners know that the stateless client is being shutdown.
+		///
+		/// In particular, the background thread that is used to refresh the token is stopped.
+		/// </summary>
+		public void Shutdown();
 	}
 }

--- a/Gotrue/Interfaces/IGotrueStatelessClient.cs
+++ b/Gotrue/Interfaces/IGotrueStatelessClient.cs
@@ -2,37 +2,253 @@
 using System.Threading.Tasks;
 using static Supabase.Gotrue.Constants;
 using static Supabase.Gotrue.StatelessClient;
-#pragma warning disable CS1591
 
 namespace Supabase.Gotrue.Interfaces
 {
+    /// <summary>
+    /// A Stateless Gotrue Client
+    /// </summary>
+    /// <example>
+    /// var options = new StatelessClientOptions { Url = "https://mygotrueurl.com" };
+    /// var user = await client.SignIn("user@email.com", "fancyPassword", options);
+    /// </example>
     public interface IGotrueStatelessClient<TUser, TSession>
         where TUser : User
         where TSession : Session
     {
+        /// <summary>
+        /// Create a user
+        /// </summary>
+        /// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
+        /// <param name="options"></param>
+        /// <param name="attributes"></param>
+        /// <returns></returns>
         Task<TUser?> CreateUser(string jwt, StatelessClientOptions options, AdminUserAttributes attributes);
+      
+        /// <summary>
+        /// Create a user
+        /// </summary>
+        /// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
+        /// <param name="options"></param>
+        /// <param name="email"></param>
+        /// <param name="password"></param>
+        /// <param name="attributes"></param>
+        /// <returns></returns>
         Task<TUser?> CreateUser(string jwt, StatelessClientOptions options, string email, string password, AdminUserAttributes? attributes = null);
+        
+        /// <summary>
+        /// Deletes a User.
+        /// </summary>
+        /// <param name="uid"></param>
+        /// <param name="jwt">this token needs role 'supabase_admin' or 'service_role'</param>
+        /// <param name="options"></param>
+        /// <returns></returns>
         Task<bool> DeleteUser(string uid, string jwt, StatelessClientOptions options);
+        
+        /// <summary>
+        /// Initialize/retrieve the underlying API for this client
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns></returns>
         IGotrueApi<TUser, TSession> GetApi(StatelessClientOptions options);
+        
+        /// <summary>
+        /// Parses a <see cref="Session"/> out of a <see cref="Uri"/>'s Query parameters.
+        /// </summary>
+        /// <param name="uri"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
         Task<TSession?> GetSessionFromUrl(Uri uri, StatelessClientOptions options);
+        
+        /// <summary>
+        /// Get User details by JWT. Can be used to validate a JWT.
+        /// </summary>
+        /// <param name="jwt">A valid JWT. Must be a JWT that originates from a user.</param>
+        /// <param name="options"></param>
+        /// <returns></returns>
         Task<TUser?> GetUser(string jwt, StatelessClientOptions options);
+        
+        /// <summary>
+        /// Get User details by Id
+        /// </summary>
+        /// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
+        /// <param name="options"></param>
+        /// <param name="userId"></param>
+        /// <returns></returns>
         Task<TUser?> GetUserById(string jwt, StatelessClientOptions options, string userId);
+        
+        /// <summary>
+        /// Sends an invite email link to the specified email.
+        /// </summary>
+        /// <param name="email"></param>
+        /// <param name="jwt">this token needs role 'supabase_admin' or 'service_role'</param>
+        /// <param name="options"></param>
+        /// <returns></returns>
         Task<bool> InviteUserByEmail(string email, string jwt, StatelessClientOptions options);
+        
+        /// <summary>
+        /// Lists users
+        /// </summary>
+        /// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
+        /// <param name="options"></param>
+        /// <param name="filter">A string for example part of the email</param>
+        /// <param name="sortBy">Snake case string of the given key, currently only created_at is supported</param>
+        /// <param name="sortOrder">asc or desc, if null desc is used</param>
+        /// <param name="page">page to show for pagination</param>
+        /// <param name="perPage">items per page for pagination</param>
+        /// <returns></returns>
         Task<UserList<User>?> ListUsers(string jwt, StatelessClientOptions options, string? filter = null, string? sortBy = null, SortOrder sortOrder = SortOrder.Descending, int? page = null, int? perPage = null);
+    
+        /// <summary>
+        /// Refreshes a Token
+        /// </summary>
+        /// <returns></returns>
         Task<TSession?> RefreshToken(string refreshToken, StatelessClientOptions options);
+        
+        /// <summary>
+        /// Sends a reset request to an email address.
+        /// </summary>
+        /// <param name="email"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
         Task<bool> ResetPasswordForEmail(string email, StatelessClientOptions options);
+        
+        /// <summary>
+        /// Sends a Magic email login link to the specified email.
+        /// </summary>
+        /// <param name="email"></param>
+        /// <param name="options"></param>
+        /// <param name="signInOptions"></param>
+        /// <returns></returns>
         Task<bool> SendMagicLink(string email, StatelessClientOptions options, SignInOptions? signInOptions = null);
+    
+        /// <summary>
+        /// Retrieves a Url to redirect to for signing in with a <see cref="Provider"/>.
+        /// 
+        /// This method will need to be combined with <see cref="GetSessionFromUrl(Uri,StatelessClientOptions)"/> when the
+        /// Application receives the Oauth Callback.
+        /// </summary>
+        /// <example>
+        /// var client = Supabase.Gotrue.Client.Initialize(options);
+        /// var url = client.SignIn(Provider.Github);
+        /// 
+        /// // Do Redirect User
+        /// 
+        /// // Example code
+        /// Application.HasReceivedOauth += async (uri) => {
+        ///     var session = await client.GetSessionFromUri(uri, true);
+        /// }
+        /// </example>
+        /// <param name="provider"></param>
+        /// <param name="options"></param>
+        /// <param name="signInOptions"></param>
+        /// <returns></returns>
         ProviderAuthState SignIn(Provider provider, StatelessClientOptions options, SignInOptions? signInOptions = null);
+      
+        /// <summary>
+        /// Log in an existing user, or login via a third-party provider.
+        /// </summary>
+        /// <param name="type">Type of Credentials being passed</param>
+        /// <param name="identifierOrToken">An email, phone, or RefreshToken</param>
+        /// <param name="password">Password to account (optional if `RefreshToken`)</param>
+        /// <param name="options"></param>
+        /// <returns></returns>
         Task<TSession?> SignIn(SignInType type, string identifierOrToken, string? password = null, StatelessClientOptions? options = null);
+       
+        /// <summary>
+        /// Sends a Magic email login link to the specified email.
+        /// </summary>
+        /// <param name="email"></param>
+        /// <param name="options"></param>
+        /// <param name="signInOptions"></param>
+        /// <returns></returns>
         Task<bool> SignIn(string email, StatelessClientOptions options, SignInOptions? signInOptions = null);
+    
+        /// <summary>
+        /// Signs in a User with an email address and password.
+        /// </summary>
+        /// <param name="email"></param>
+        /// <param name="password"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
         Task<TSession?> SignIn(string email, string password, StatelessClientOptions options);
+     
+        /// <summary>
+        /// Logout a User
+        /// This will revoke all refresh tokens for the user.
+        /// JWT tokens will still be valid for stateless auth until they expire.
+        /// </summary>
+        /// <param name="jwt"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
         Task<bool> SignOut(string jwt, StatelessClientOptions options);
+        
+        /// <summary>
+        /// Signs up a user
+        /// </summary>
+        /// <param name="type">Type of signup</param>
+        /// <param name="identifier">Phone or Email</param>
+        /// <param name="password"></param>
+        /// <param name="options"></param>
+        /// <param name="signUpOptions">Object containing redirectTo and optional user metadata (data)</param>
+        /// <returns></returns>
         Task<TSession?> SignUp(SignUpType type, string identifier, string password, StatelessClientOptions options, SignUpOptions? signUpOptions = null);
+      
+        /// <summary>
+        /// Signs up a user by email address
+        /// </summary>
+        /// <param name="email"></param>
+        /// <param name="password"></param>
+        /// <param name="options"></param>
+        /// <param name="signUpOptions">Object containing redirectTo and optional user metadata (data)</param>
+        /// <returns></returns>
         Task<TSession?> SignUp(string email, string password, StatelessClientOptions options, SignUpOptions? signUpOptions = null);
+     
+        /// <summary>
+        /// Updates a User's attributes
+        /// </summary>
+        /// <param name="accessToken"></param>
+        /// <param name="attributes"></param>
+        /// <param name="options"></param>
+        /// <returns></returns>
         Task<TUser?> Update(string accessToken, UserAttributes attributes, StatelessClientOptions options);
+     
+        /// <summary>
+        /// Update user by Id
+        /// </summary>
+        /// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
+        /// <param name="options"></param>
+        /// <param name="userId"></param>
+        /// <param name="userData"></param>
+        /// <returns></returns>
         Task<TUser?> UpdateUserById(string jwt, StatelessClientOptions options, string userId, AdminUserAttributes userData);
+   
+        /// <summary>
+        /// Log in a user given a User supplied OTP received via mobile.
+        /// </summary>
+        /// <param name="phone">The user's phone number.</param>
+        /// <param name="token">Token sent to the user's phone.</param>
+        /// <param name="options"></param>
+        /// <param name="type"></param>
+        /// <returns></returns>
         Task<TSession?> VerifyOTP(string phone, string token, StatelessClientOptions options, MobileOtpType type = MobileOtpType.SMS);
+       
+        /// <summary>
+        /// Log in a user give a user supplied OTP received via email.
+        /// </summary>
+        /// <param name="email"></param>
+        /// <param name="token"></param>
+        /// <param name="options"></param>
+        /// <param name="type"></param>
+        /// <returns></returns>
         Task<TSession?> VerifyOTP(string email, string token, StatelessClientOptions options, EmailOtpType type = EmailOtpType.MagicLink);
+
+        /// <summary>
+        /// Retrieve the current settings for the Gotrue instance.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns></returns>
         Task<Settings?> Settings(StatelessClientOptions options);
     }
 }

--- a/Gotrue/NetworkStatus.cs
+++ b/Gotrue/NetworkStatus.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net.NetworkInformation;
 using System.Threading.Tasks;
-
 namespace Supabase.Gotrue
 {
 	/// <summary>

--- a/Gotrue/PersistenceListener.cs
+++ b/Gotrue/PersistenceListener.cs
@@ -1,6 +1,5 @@
 using System;
 using Supabase.Gotrue.Interfaces;
-
 namespace Supabase.Gotrue
 {
 	/// <summary>
@@ -57,6 +56,9 @@ namespace Supabase.Gotrue
 					{
 						Persistence.SaveSession(sender.CurrentSession);
 					}
+					break;
+				case Constants.AuthState.Shutdown:
+					// The session should have already been saved, so we don't need to do anything here.
 					break;
 				default: throw new ArgumentOutOfRangeException(nameof(stateChanged), stateChanged, null);
 			}

--- a/Gotrue/ProviderAuthState.cs
+++ b/Gotrue/ProviderAuthState.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-
 namespace Supabase.Gotrue
 {
     /// <summary>
@@ -19,6 +18,10 @@ namespace Supabase.Gotrue
         /// </summary>
         public string? PKCEVerifier { get; set; }
 
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="uri"></param>
         public ProviderAuthState(Uri uri)
         {
             Uri = uri;

--- a/Gotrue/Responses/BaseResponse.cs
+++ b/Gotrue/Responses/BaseResponse.cs
@@ -1,6 +1,5 @@
 ﻿using System.Net.Http;
 using Newtonsoft.Json;
-
 namespace Supabase.Gotrue.Responses
 {
     /// <summary>

--- a/Gotrue/SignInWithPasswordlessEmailOptions.cs
+++ b/Gotrue/SignInWithPasswordlessEmailOptions.cs
@@ -57,10 +57,19 @@ namespace Supabase.Gotrue
 	/// <inheritdoc />
 	public class SignInWithPasswordlessPhoneOptions : SignInWithPasswordlessOptions
 	{
+		/// <summary>
+		/// Represents a messaging channel to use for sending the OTP.
+		/// </summary>
 		public enum MessagingChannel
 		{
+			/// <summary>
+			/// SMS
+			/// </summary>
 			[MapTo("sms")]
 			SMS,
+			/// <summary>
+			/// 
+			/// </summary>
 			[MapTo("whatsapp")]
 			WHATSAPP
 		}

--- a/Gotrue/SignUpOptions.cs
+++ b/Gotrue/SignUpOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-
 namespace Supabase.Gotrue
 {
     /// <summary>

--- a/Gotrue/StatelessClient.cs
+++ b/Gotrue/StatelessClient.cs
@@ -7,42 +7,23 @@ using static Supabase.Gotrue.Constants;
 
 namespace Supabase.Gotrue
 {
-	/// <summary>
-	/// A Stateless Gotrue Client
-	/// </summary>
-	/// <example>
-	/// var options = new StatelessClientOptions { Url = "https://mygotrueurl.com" };
-	/// var user = await client.SignIn("user@email.com", "fancyPassword", options);
-	/// </example>
+	/// <inheritdoc />
 	public class StatelessClient : IGotrueStatelessClient<User, Session>
 	{
+		/// <inheritdoc />
 		public async Task<Settings?> Settings(StatelessClientOptions options)
 		{
 			var api = GetApi(options);
 			return await api.Settings();
 		}
 
+		/// <inheritdoc />
 		public IGotrueApi<User, Session> GetApi(StatelessClientOptions options) => new Api(options.Url, options.Headers);
-
-		/// <summary>
-		/// Signs up a user by email address
-		/// </summary>
-		/// <param name="email"></param>
-		/// <param name="password"></param>
-		/// <param name="options"></param>
-		/// <param name="signUpOptions">Object containing redirectTo and optional user metadata (data)</param>
-		/// <returns></returns>
+		
+		/// <inheritdoc />
 		public Task<Session?> SignUp(string email, string password, StatelessClientOptions options, SignUpOptions? signUpOptions = null) => SignUp(SignUpType.Email, email, password, options, signUpOptions);
-
-		/// <summary>
-		/// Signs up a user
-		/// </summary>
-		/// <param name="type">Type of signup</param>
-		/// <param name="identifier">Phone or Email</param>
-		/// <param name="password"></param>
-		/// <param name="options"></param>
-		/// <param name="signUpOptions">Object containing redirectTo and optional user metadata (data)</param>
-		/// <returns></returns>
+		
+		/// <inheritdoc />
 		public async Task<Session?> SignUp(SignUpType type, string identifier, string password, StatelessClientOptions options, SignUpOptions? signUpOptions = null)
 		{
 			var api = GetApi(options);
@@ -60,50 +41,23 @@ namespace Supabase.Gotrue
 
 			return null;
 		}
-
-
-		/// <summary>
-		/// Sends a Magic email login link to the specified email.
-		/// </summary>
-		/// <param name="email"></param>
-		/// <param name="options"></param>
-		/// <param name="signInOptions"></param>
-		/// <returns></returns>
+		
+		/// <inheritdoc />
 		public async Task<bool> SignIn(string email, StatelessClientOptions options, SignInOptions? signInOptions = null)
 		{
 			await GetApi(options).SendMagicLinkEmail(email, signInOptions);
 			return true;
 		}
-
-		/// <summary>
-		/// Sends a Magic email login link to the specified email.
-		/// </summary>
-		/// <param name="email"></param>
-		/// <param name="options"></param>
-		/// <param name="signInOptions"></param>
-		/// <returns></returns>
+		
+		/// <inheritdoc />
 		public Task<bool> SendMagicLink(string email, StatelessClientOptions options, SignInOptions? signInOptions = null) => SignIn(email, options, signInOptions);
-
-		/// <summary>
-		/// Signs in a User.
-		/// </summary>
-		/// <param name="email"></param>
-		/// <param name="password"></param>
-		/// <param name="options"></param>
-		/// <returns></returns>
+		
+		/// <inheritdoc />
 		public Task<Session?> SignIn(string email, string password, StatelessClientOptions options) => SignIn(SignInType.Email, email, password, options);
-
-		/// <summary>
-		/// Log in an existing user, or login via a third-party provider.
-		/// </summary>
-		/// <param name="type">Type of Credentials being passed</param>
-		/// <param name="identifierOrToken">An email, phone, or RefreshToken</param>
-		/// <param name="password">Password to account (optional if `RefreshToken`)</param>
-		/// <param name="options"></param>
-		/// <returns></returns>
+		
+		/// <inheritdoc />
 		public async Task<Session?> SignIn(SignInType type, string identifierOrToken, string? password = null, StatelessClientOptions? options = null)
 		{
-
 			options ??= new StatelessClientOptions();
 
 			var api = GetApi(options);
@@ -136,52 +90,18 @@ namespace Supabase.Gotrue
 			return null;
 		}
 
-		/// <summary>
-		/// Retrieves a Url to redirect to for signing in with a <see cref="Provider"/>.
-		/// 
-		/// This method will need to be combined with <see cref="GetSessionFromUrl(Uri,StatelessClientOptions)"/> when the
-		/// Application receives the Oauth Callback.
-		/// </summary>
-		/// <example>
-		/// var client = Supabase.Gotrue.Client.Initialize(options);
-		/// var url = client.SignIn(Provider.Github);
-		/// 
-		/// // Do Redirect User
-		/// 
-		/// // Example code
-		/// Application.HasReceivedOauth += async (uri) => {
-		///     var session = await client.GetSessionFromUri(uri, true);
-		/// }
-		/// </example>
-		/// <param name="provider"></param>
-		/// <param name="options"></param>
-		/// <param name="signInOptions"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public ProviderAuthState SignIn(Provider provider, StatelessClientOptions options, SignInOptions? signInOptions = null) => GetApi(options).GetUriForProvider(provider, signInOptions);
 
-		/// <summary>
-		/// Logout a User
-		/// This will revoke all refresh tokens for the user.
-		/// JWT tokens will still be valid for stateless auth until they expire.
-		/// </summary>
-		/// <param name="jwt"></param>
-		/// <param name="options"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public async Task<bool> SignOut(string jwt, StatelessClientOptions options)
 		{
 			var result = await GetApi(options).SignOut(jwt);
 			result.ResponseMessage?.EnsureSuccessStatusCode();
 			return true;
 		}
-
-		/// <summary>
-		/// Log in a user given a User supplied OTP received via mobile.
-		/// </summary>
-		/// <param name="phone">The user's phone number.</param>
-		/// <param name="token">Token sent to the user's phone.</param>
-		/// <param name="options"></param>
-		/// <param name="type"></param>
-		/// <returns></returns>
+		
+		/// <inheritdoc />
 		public async Task<Session?> VerifyOTP(string phone, string token, StatelessClientOptions options, MobileOtpType type = MobileOtpType.SMS)
 		{
 			var session = await GetApi(options).VerifyMobileOTP(phone, token, type);
@@ -194,14 +114,7 @@ namespace Supabase.Gotrue
 			return null;
 		}
 
-		/// <summary>
-		/// Log in a user give a user supplied OTP received via email.
-		/// </summary>
-		/// <param name="email"></param>
-		/// <param name="token"></param>
-		/// <param name="options"></param>
-		/// <param name="type"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public async Task<Session?> VerifyOTP(string email, string token, StatelessClientOptions options, EmailOtpType type = EmailOtpType.MagicLink)
 		{
 			var session = await GetApi(options).VerifyEmailOTP(email, token, type);
@@ -214,27 +127,14 @@ namespace Supabase.Gotrue
 			return null;
 		}
 
-
-		/// <summary>
-		/// Updates a User.
-		/// </summary>
-		/// <param name="accessToken"></param>
-		/// <param name="attributes"></param>
-		/// <param name="options"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public async Task<User?> Update(string accessToken, UserAttributes attributes, StatelessClientOptions options)
 		{
 			var result = await GetApi(options).UpdateUser(accessToken, attributes);
 			return result;
 		}
 
-		/// <summary>
-		/// Sends an invite email link to the specified email.
-		/// </summary>
-		/// <param name="email"></param>
-		/// <param name="jwt">this token needs role 'supabase_admin' or 'service_role'</param>
-		/// <param name="options"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public async Task<bool> InviteUserByEmail(string email, string jwt, StatelessClientOptions options)
 		{
 			var response = await GetApi(options).InviteUserByEmail(email, jwt);
@@ -242,13 +142,7 @@ namespace Supabase.Gotrue
 			return true;
 		}
 
-		/// <summary>
-		/// Sends a reset request to an email address.
-		/// </summary>
-		/// <param name="email"></param>
-		/// <param name="options"></param>
-		/// <returns></returns>
-		/// <exception cref="Exception"></exception>
+		/// <inheritdoc />
 		public async Task<bool> ResetPasswordForEmail(string email, StatelessClientOptions options)
 		{
 			var result = await GetApi(options).ResetPasswordForEmail(email);
@@ -256,55 +150,26 @@ namespace Supabase.Gotrue
 			return true;
 		}
 
-		/// <summary>
-		/// Lists users
-		/// </summary>
-		/// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
-		/// <param name="options"></param>
-		/// <param name="filter">A string for example part of the email</param>
-		/// <param name="sortBy">Snake case string of the given key, currently only created_at is supported</param>
-		/// <param name="sortOrder">asc or desc, if null desc is used</param>
-		/// <param name="page">page to show for pagination</param>
-		/// <param name="perPage">items per page for pagination</param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public async Task<UserList<User>?> ListUsers(string jwt, StatelessClientOptions options, string? filter = null, string? sortBy = null, SortOrder sortOrder = SortOrder.Descending,
 			int? page = null, int? perPage = null)
 		{
 			return await GetApi(options).ListUsers(jwt, filter, sortBy, sortOrder, page, perPage);
 		}
 
-		/// <summary>
-		/// Get User details by Id
-		/// </summary>
-		/// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
-		/// <param name="options"></param>
-		/// <param name="userId"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public async Task<User?> GetUserById(string jwt, StatelessClientOptions options, string userId)
 		{
 			return await GetApi(options).GetUserById(jwt, userId);
 		}
 
-		/// <summary>
-		/// Get User details by JWT. Can be used to validate a JWT.
-		/// </summary>
-		/// <param name="jwt">A valid JWT. Must be a JWT that originates from a user.</param>
-		/// <param name="options"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public async Task<User?> GetUser(string jwt, StatelessClientOptions options)
 		{
 			return await GetApi(options).GetUser(jwt);
 		}
 
-		/// <summary>
-		/// Create a user
-		/// </summary>
-		/// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
-		/// <param name="options"></param>
-		/// <param name="email"></param>
-		/// <param name="password"></param>
-		/// <param name="attributes"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public Task<User?> CreateUser(string jwt, StatelessClientOptions options, string email, string password, AdminUserAttributes? attributes = null)
 		{
 			attributes ??= new AdminUserAttributes();
@@ -314,38 +179,19 @@ namespace Supabase.Gotrue
 			return CreateUser(jwt, options, attributes);
 		}
 
-		/// <summary>
-		/// Create a user
-		/// </summary>
-		/// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
-		/// <param name="options"></param>
-		/// <param name="attributes"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public async Task<User?> CreateUser(string jwt, StatelessClientOptions options, AdminUserAttributes attributes)
 		{
 			return await GetApi(options).CreateUser(jwt, attributes);
 		}
 
-		/// <summary>
-		/// Update user by Id
-		/// </summary>
-		/// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
-		/// <param name="options"></param>
-		/// <param name="userId"></param>
-		/// <param name="userData"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public async Task<User?> UpdateUserById(string jwt, StatelessClientOptions options, string userId, AdminUserAttributes userData)
 		{
 			return await GetApi(options).UpdateUserById(jwt, userId, userData);
 		}
 
-		/// <summary>
-		/// Deletes a User.
-		/// </summary>
-		/// <param name="uid"></param>
-		/// <param name="jwt">this token needs role 'supabase_admin' or 'service_role'</param>
-		/// <param name="options"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public async Task<bool> DeleteUser(string uid, string jwt, StatelessClientOptions options)
 		{
 			var result = await GetApi(options).DeleteUser(uid, jwt);
@@ -353,12 +199,7 @@ namespace Supabase.Gotrue
 			return true;
 		}
 
-		/// <summary>
-		/// Parses a <see cref="Session"/> out of a <see cref="Uri"/>'s Query parameters.
-		/// </summary>
-		/// <param name="uri"></param>
-		/// <param name="options"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public async Task<Session?> GetSessionFromUrl(Uri uri, StatelessClientOptions options)
 		{
 			var query = HttpUtility.ParseQueryString(uri.Query);
@@ -402,12 +243,8 @@ namespace Supabase.Gotrue
 			return session;
 		}
 
-		/// <summary>
-		/// Refreshes a Token
-		/// </summary>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public async Task<Session?> RefreshToken(string refreshToken, StatelessClientOptions options) => await GetApi(options).RefreshAccessToken(refreshToken);
-
 
 		/// <summary>
 		/// Class representation options available to the <see cref="Client"/>.
@@ -433,5 +270,4 @@ namespace Supabase.Gotrue
 			public bool AllowUnconfirmedUserSessions { get; set; }
 		}
 	}
-
 }

--- a/Gotrue/TokenRefresh.cs
+++ b/Gotrue/TokenRefresh.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Net.Http;
 using System.Threading;
-using Supabase.Gotrue.Exceptions;
 using Supabase.Gotrue.Interfaces;
 using static Supabase.Gotrue.Constants.AuthState;
 
@@ -60,6 +58,11 @@ namespace Supabase.Gotrue
 					break;
 				case TokenRefreshed:
 					// Doesn't affect auto refresh
+					break;
+				case Shutdown:
+					_client.Debug("Refresh Timer stopped");
+					_refreshTimer?.Dispose();
+					// Turn off auto-refresh timer
 					break;
 				default: throw new ArgumentOutOfRangeException(nameof(stateChanged), stateChanged, null);
 			}

--- a/GotrueTests/NetworkTests.cs
+++ b/GotrueTests/NetworkTests.cs
@@ -96,7 +96,13 @@ namespace GotrueTests
 				x = gte;
 			}
 			Assert.AreEqual(FailureHint.Reason.Offline, x?.Reason);
-		}
 
+			// Now let's go online and give it another try.
+			client.Online = true;
+			await client.RefreshToken();
+
+			// Let's try shutting down.
+			client.Shutdown();
+		}
 	}
 }

--- a/gotrue-csharp.sln.DotSettings
+++ b/gotrue-csharp.sln.DotSettings
@@ -44,6 +44,7 @@
     <s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForSimpleTypes/@EntryValue">UseVar</s:String>
     <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SHA/@EntryIndexedValue">SHA</s:String>
     <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SMS/@EntryIndexedValue">SMS</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=WHATSAPP/@EntryIndexedValue">WHATSAPP</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
@@ -56,4 +57,5 @@
     <s:Boolean x:Key="/Default/UserDictionary/Words/=Gotrue/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/UserDictionary/Words/=magiclink/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/UserDictionary/Words/=PKCE/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reauthenticate/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/UserDictionary/Words/=Supabase/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a Shutdown option to the auth state notification. This provides a mechanism to manually terminate the background refresh thread without logging out. This allows the client to be used cleanly when running in the Unity editor.

In addition, went ahead and moved the docs to the interfaces and inherit docs on the implementation - less copy and paste FTW.

## What is the current behavior?

Only user visible / API change is the addition of the Shutdown auth state. It's possible that if client code is throwing an exception on an unexpected state change they might get an exception here. This is the kind of thing that IDEs like Rider are pretty good at catching in static code analysis FWIW.

Oh, and now the docs should be visible for IDEs when working with both the interfaces and the implementation code.