### PR TITLE
Change Network Status to use the interface instead of client

### DIFF
--- a/Gotrue/NetworkStatus.cs
+++ b/Gotrue/NetworkStatus.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net.NetworkInformation;
 using System.Threading.Tasks;
+using Supabase.Gotrue.Interfaces;
 namespace Supabase.Gotrue
 {
 	/// <summary>
@@ -12,12 +13,12 @@ namespace Supabase.Gotrue
 	/// </summary>
 	public class NetworkStatus
 	{
-		private readonly Client _client;
+		private readonly IGotrueClient<User, Session> _client;
 		/// <summary>
 		/// Set up a listener for the network status.
 		/// </summary>
 		/// <param name="client"></param>
-		public NetworkStatus(Client client)
+		public NetworkStatus(IGotrueClient<User, Session> client)
 		{
 			_client = client;
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Right now to use NetworkStatus with the parent/main Supabase client the parent Supabase.Auth has to be cast to client. This fixes NetworkStatus to use the interface instead, avoiding the cast.

## What is the current behavior?

Works but needs a cast.
