### PR TITLE
Fix for #71

### DIFF
--- a/Gotrue/Api.cs
+++ b/Gotrue/Api.cs
@@ -599,19 +599,25 @@ namespace Supabase.Gotrue
 		{
 			return Helpers.MakeRequest<Settings>(HttpMethod.Get, $"{Url}/settings", null, Headers);
 		}
-
+		
 		/// <summary>
-		/// Generates a new JWT
+		/// Generates a new Session given a user's access token and refresh token.
 		/// </summary>
 		/// <param name="refreshToken"></param>
+		/// <param name="accessToken"></param>
 		/// <returns></returns>
-		public Task<Session?> RefreshAccessToken(string refreshToken)
+		public Task<Session?> RefreshAccessToken(string accessToken, string refreshToken)
 		{
+			var headers = new Dictionary<string, string>
+			{
+				{ "Authorization", $"Bearer {accessToken}" },
+			};
+			
 			var data = new Dictionary<string, string> {
 				{ "refresh_token", refreshToken }
 			};
 
-			return Helpers.MakeRequest<Session>(HttpMethod.Post, $"{Url}/token?grant_type=refresh_token", data, Headers);
+			return Helpers.MakeRequest<Session>(HttpMethod.Post, $"{Url}/token?grant_type=refresh_token", data, Headers.MergeLeft(headers));
 		}
 	}
 }

--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -262,19 +262,21 @@ namespace Supabase.Gotrue
 					UpdateSession(newSession);
 					break;
 				case SignInType.RefreshToken:
-					await RefreshToken(identifierOrToken);
+					if (CurrentSession == null || string.IsNullOrEmpty(CurrentSession.AccessToken))
+						throw new GotrueException("Not logged in.", NoSessionFound);
+					
+					await RefreshToken(CurrentSession.AccessToken!, identifierOrToken);
 					return CurrentSession;
 				default: throw new ArgumentOutOfRangeException(nameof(type), type, null);
 			}
 
-			if (newSession?.User?.ConfirmedAt != null ||
-			    newSession?.User != null && Options.AllowUnconfirmedUserSessions)
-			{
-				NotifyAuthStateChange(SignedIn);
-				return CurrentSession;
-			}
+			// Handle case when a user registers and has not confirmed email (and options do not allow for this), return null for session.
+			if (newSession?.User?.ConfirmedAt == null &&
+			    (newSession?.User == null || !Options.AllowUnconfirmedUserSessions))
+				return null;
 
-			return null;
+			NotifyAuthStateChange(SignedIn);
+			return CurrentSession;
 		}
 
 
@@ -399,15 +401,20 @@ namespace Supabase.Gotrue
 		}
 
 		/// <inheritdoc />
-		public Session SetAuth(string accessToken)
+		public async Task<Session> SetSession(string accessToken, string refreshToken)
 		{
-			CurrentSession ??= new Session();
+			DestroySession();
+			
+			if (string.IsNullOrEmpty(accessToken) || string.IsNullOrEmpty(refreshToken))
+				throw new GotrueException("`access_token` and `refresh_token` cannot be empty.", NoSessionFound);
 
-			CurrentSession.AccessToken = accessToken;
-			CurrentSession.TokenType = "bearer";
-			CurrentSession.User = CurrentUser;
+			var result = await _api.RefreshAccessToken(accessToken, refreshToken);
 
-			NotifyAuthStateChange(TokenRefreshed);
+			if (result == null || string.IsNullOrEmpty(result.AccessToken))
+				throw new GotrueException("Could not generate a session given the provided parameters.", NoSessionFound);
+
+			CurrentSession = result;
+			NotifyAuthStateChange(SignedIn);
 			return CurrentSession;
 		}
 
@@ -568,16 +575,13 @@ namespace Supabase.Gotrue
 			UpdateSession(null);
 		}
 
-		/// <summary>
-		/// Refreshes a Token using the provided token.
-		/// </summary>
-		/// <returns></returns>
-		public async Task RefreshToken(string refreshToken)
+		/// <inheritdoc />
+		public async Task RefreshToken(string accessToken, string refreshToken)
 		{
-			if (string.IsNullOrEmpty(refreshToken))
+			if (string.IsNullOrEmpty(accessToken) || string.IsNullOrEmpty(refreshToken))
 				throw new GotrueException("No token provided", NoSessionFound);
 
-			var result = await _api.RefreshAccessToken(refreshToken);
+			var result = await _api.RefreshAccessToken(refreshToken, accessToken);
 
 			if (result == null || string.IsNullOrEmpty(result.AccessToken))
 				throw new GotrueException("Could not refresh token from provided session.", NoSessionFound);
@@ -586,22 +590,19 @@ namespace Supabase.Gotrue
 			NotifyAuthStateChange(TokenRefreshed);
 		}
 
-		/// <summary>
-		/// Refreshes a Token. If no token is provided, the current session is used.
-		/// </summary>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public async Task RefreshToken()
 		{
 			if (!Online)
 				throw new GotrueException("Only supported when online", Offline);
 
-			if (CurrentSession == null || string.IsNullOrEmpty(CurrentSession?.RefreshToken))
+			if (CurrentSession == null || string.IsNullOrEmpty(CurrentSession?.AccessToken) || string.IsNullOrEmpty(CurrentSession?.RefreshToken))
 				throw new GotrueException("No current session.", NoSessionFound);
 
 			if (CurrentSession!.Expired())
 				throw new GotrueException("Session expired", ExpiredRefreshToken);
 
-			var result = await _api.RefreshAccessToken(CurrentSession.RefreshToken!);
+			var result = await _api.RefreshAccessToken(CurrentSession.AccessToken!, CurrentSession.RefreshToken!);
 
 			if (result == null || string.IsNullOrEmpty(result.AccessToken))
 				throw new GotrueException("Could not refresh token from provided session.", NoSessionFound);

--- a/Gotrue/Gotrue.csproj
+++ b/Gotrue/Gotrue.csproj
@@ -52,6 +52,7 @@
         <LangVersion>8.0</LangVersion>
     </PropertyGroup>
     <ItemGroup>
+        <PackageReference Include="JWTDecoder" Version="0.9.2" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="supabase-core" Version="0.0.3" />
     </ItemGroup>

--- a/Gotrue/Interfaces/IGotrueApi.cs
+++ b/Gotrue/Interfaces/IGotrueApi.cs
@@ -16,7 +16,7 @@ namespace Supabase.Gotrue.Interfaces
 		Task<TUser?> GetUserById(string jwt, string userId);
 		Task<BaseResponse> InviteUserByEmail(string email, string jwt);
 		Task<UserList<TUser>?> ListUsers(string jwt, string? filter = null, string? sortBy = null, SortOrder sortOrder = SortOrder.Descending, int? page = null, int? perPage = null);
-		Task<TSession?> RefreshAccessToken(string refreshToken);
+		Task<TSession?> RefreshAccessToken(string accessToken, string refreshToken);
 		Task<BaseResponse> ResetPasswordForEmail(string email);
 		Task<BaseResponse> SendMagicLinkEmail(string email, SignInOptions? options = null);
 		Task<BaseResponse> SendMobileOTP(string phone);

--- a/Gotrue/Interfaces/IGotrueClient.cs
+++ b/Gotrue/Interfaces/IGotrueClient.cs
@@ -137,12 +137,18 @@ namespace Supabase.Gotrue.Interfaces
 		Task<bool> SendMagicLink(string email, SignInOptions? options = null);
 
 		/// <summary>
-		///  Overrides the JWT access token for the current session. The access token will
-		/// then be sent in all subsequent network requests.
+		/// Sets a new session given a user's access token and their refresh token.
+		/// 
+		/// 1. Will destroy the current session (if existing)
+		/// 2. Raise a <see cref="AuthState.SignedOut"/> event.
+		/// 3. Request a new session from the server using the provided parameters (effectively validating them).
+		/// 4. Raise a `<see cref="AuthState.SignedIn"/> event if successful.
 		/// </summary>
-		/// <param name="accessToken">The JWT access token.</param>
-		/// <returns>Session.</returns>
-		TSession SetAuth(string accessToken);
+		/// <param name="accessToken"></param>
+		/// <param name="refreshToken"></param>
+		/// <returns></returns>
+		/// <exception cref="GotrueException">Raised when token combination is invalid.</exception>
+		Task<TSession> SetSession(string accessToken, string refreshToken);
 
 		/// <summary>
 		/// Log in an existing user, or login via a third-party provider.
@@ -381,5 +387,11 @@ namespace Supabase.Gotrue.Interfaces
 		/// In particular, the background thread that is used to refresh the token is stopped.
 		/// </summary>
 		public void Shutdown();
+
+		/// <summary>
+		/// Refreshes a Token using the current session.
+		/// </summary>
+		/// <returns></returns>
+		public Task RefreshToken();
 	}
 }

--- a/Gotrue/Interfaces/IGotrueClient.cs
+++ b/Gotrue/Interfaces/IGotrueClient.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Supabase.Core.Interfaces;
 using Supabase.Gotrue.Exceptions;
 using static Supabase.Gotrue.Constants;
+
 #pragma warning disable CS1591
 
 namespace Supabase.Gotrue.Interfaces
@@ -141,14 +142,17 @@ namespace Supabase.Gotrue.Interfaces
 		/// 
 		/// 1. Will destroy the current session (if existing)
 		/// 2. Raise a <see cref="AuthState.SignedOut"/> event.
-		/// 3. Request a new session from the server using the provided parameters (effectively validating them).
+		/// 3. Decode token
+		///	  3a. If expired (or bool <paramref name="forceAccessTokenRefresh"></paramref> set), force an access token refresh.
+		///   3b. If not expired, set the <see cref="CurrentSession"/> and retrieve <see cref="CurrentUser"/> from the server using the <paramref name="accessToken"/>.
 		/// 4. Raise a `<see cref="AuthState.SignedIn"/> event if successful.
 		/// </summary>
 		/// <param name="accessToken"></param>
 		/// <param name="refreshToken"></param>
+		/// <param name="forceAccessTokenRefresh"></param>
 		/// <returns></returns>
 		/// <exception cref="GotrueException">Raised when token combination is invalid.</exception>
-		Task<TSession> SetSession(string accessToken, string refreshToken);
+		Task<TSession> SetSession(string accessToken, string refreshToken, bool forceAccessTokenRefresh = false);
 
 		/// <summary>
 		/// Log in an existing user, or login via a third-party provider.
@@ -354,7 +358,7 @@ namespace Supabase.Gotrue.Interfaces
 		/// Loads the session from the persistence layer.
 		/// </summary>
 		void LoadSession();
-		
+
 		/// <summary>
 		/// Retrieves the settings from the server
 		/// </summary>
@@ -380,7 +384,7 @@ namespace Supabase.Gotrue.Interfaces
 		/// <param name="message"></param>
 		/// <param name="e"></param>
 		void Debug(string message, Exception? e = null);
-		
+
 		/// <summary>
 		/// Let all of the listeners know that the stateless client is being shutdown.
 		///

--- a/Gotrue/Interfaces/IGotrueStatelessClient.cs
+++ b/Gotrue/Interfaces/IGotrueStatelessClient.cs
@@ -19,31 +19,31 @@ namespace Supabase.Gotrue.Interfaces
         /// <summary>
         /// Create a user
         /// </summary>
-        /// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
+        /// <param name="serviceRoleToken">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
         /// <param name="options"></param>
         /// <param name="attributes"></param>
         /// <returns></returns>
-        Task<TUser?> CreateUser(string jwt, StatelessClientOptions options, AdminUserAttributes attributes);
+        Task<TUser?> CreateUser(string serviceRoleToken, StatelessClientOptions options, AdminUserAttributes attributes);
       
         /// <summary>
         /// Create a user
         /// </summary>
-        /// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
+        /// <param name="serviceRoleToken">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
         /// <param name="options"></param>
         /// <param name="email"></param>
         /// <param name="password"></param>
         /// <param name="attributes"></param>
         /// <returns></returns>
-        Task<TUser?> CreateUser(string jwt, StatelessClientOptions options, string email, string password, AdminUserAttributes? attributes = null);
+        Task<TUser?> CreateUser(string serviceRoleToken, StatelessClientOptions options, string email, string password, AdminUserAttributes? attributes = null);
         
         /// <summary>
         /// Deletes a User.
         /// </summary>
         /// <param name="uid"></param>
-        /// <param name="jwt">this token needs role 'supabase_admin' or 'service_role'</param>
+        /// <param name="serviceRoleToken">this token needs role 'supabase_admin' or 'service_role'</param>
         /// <param name="options"></param>
         /// <returns></returns>
-        Task<bool> DeleteUser(string uid, string jwt, StatelessClientOptions options);
+        Task<bool> DeleteUser(string uid, string serviceRoleToken, StatelessClientOptions options);
         
         /// <summary>
         /// Initialize/retrieve the underlying API for this client
@@ -63,33 +63,33 @@ namespace Supabase.Gotrue.Interfaces
         /// <summary>
         /// Get User details by JWT. Can be used to validate a JWT.
         /// </summary>
-        /// <param name="jwt">A valid JWT. Must be a JWT that originates from a user.</param>
+        /// <param name="serviceRoleToken">A valid JWT. Must be a JWT that originates from a user.</param>
         /// <param name="options"></param>
         /// <returns></returns>
-        Task<TUser?> GetUser(string jwt, StatelessClientOptions options);
+        Task<TUser?> GetUser(string serviceRoleToken, StatelessClientOptions options);
         
         /// <summary>
         /// Get User details by Id
         /// </summary>
-        /// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
+        /// <param name="serviceRoleToken">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
         /// <param name="options"></param>
         /// <param name="userId"></param>
         /// <returns></returns>
-        Task<TUser?> GetUserById(string jwt, StatelessClientOptions options, string userId);
+        Task<TUser?> GetUserById(string serviceRoleToken, StatelessClientOptions options, string userId);
         
         /// <summary>
         /// Sends an invite email link to the specified email.
         /// </summary>
         /// <param name="email"></param>
-        /// <param name="jwt">this token needs role 'supabase_admin' or 'service_role'</param>
+        /// <param name="serviceRoleToken">this token needs role 'supabase_admin' or 'service_role'</param>
         /// <param name="options"></param>
         /// <returns></returns>
-        Task<bool> InviteUserByEmail(string email, string jwt, StatelessClientOptions options);
+        Task<bool> InviteUserByEmail(string email, string serviceRoleToken, StatelessClientOptions options);
         
         /// <summary>
         /// Lists users
         /// </summary>
-        /// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
+        /// <param name="serviceRoleToken">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
         /// <param name="options"></param>
         /// <param name="filter">A string for example part of the email</param>
         /// <param name="sortBy">Snake case string of the given key, currently only created_at is supported</param>
@@ -97,13 +97,16 @@ namespace Supabase.Gotrue.Interfaces
         /// <param name="page">page to show for pagination</param>
         /// <param name="perPage">items per page for pagination</param>
         /// <returns></returns>
-        Task<UserList<User>?> ListUsers(string jwt, StatelessClientOptions options, string? filter = null, string? sortBy = null, SortOrder sortOrder = SortOrder.Descending, int? page = null, int? perPage = null);
+        Task<UserList<User>?> ListUsers(string serviceRoleToken, StatelessClientOptions options, string? filter = null, string? sortBy = null, SortOrder sortOrder = SortOrder.Descending, int? page = null, int? perPage = null);
     
         /// <summary>
         /// Refreshes a Token
         /// </summary>
+        /// <param name="accessToken"></param>
+        /// <param name="refreshToken"></param>
+        /// <param name="options"></param>
         /// <returns></returns>
-        Task<TSession?> RefreshToken(string refreshToken, StatelessClientOptions options);
+        Task<TSession?> RefreshToken(string accessToken, string refreshToken, StatelessClientOptions options);
         
         /// <summary>
         /// Sends a reset request to an email address.
@@ -179,10 +182,10 @@ namespace Supabase.Gotrue.Interfaces
         /// This will revoke all refresh tokens for the user.
         /// JWT tokens will still be valid for stateless auth until they expire.
         /// </summary>
-        /// <param name="jwt"></param>
+        /// <param name="accessToken"></param>
         /// <param name="options"></param>
         /// <returns></returns>
-        Task<bool> SignOut(string jwt, StatelessClientOptions options);
+        Task<bool> SignOut(string accessToken, StatelessClientOptions options);
         
         /// <summary>
         /// Signs up a user
@@ -217,32 +220,32 @@ namespace Supabase.Gotrue.Interfaces
         /// <summary>
         /// Update user by Id
         /// </summary>
-        /// <param name="jwt">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
+        /// <param name="serviceRoleToken">A valid JWT. Must be a full-access API key (e.g. service_role key).</param>
         /// <param name="options"></param>
         /// <param name="userId"></param>
         /// <param name="userData"></param>
         /// <returns></returns>
-        Task<TUser?> UpdateUserById(string jwt, StatelessClientOptions options, string userId, AdminUserAttributes userData);
+        Task<TUser?> UpdateUserById(string serviceRoleToken, StatelessClientOptions options, string userId, AdminUserAttributes userData);
    
         /// <summary>
         /// Log in a user given a User supplied OTP received via mobile.
         /// </summary>
         /// <param name="phone">The user's phone number.</param>
-        /// <param name="token">Token sent to the user's phone.</param>
+        /// <param name="otpToken">Token sent to the user's phone.</param>
         /// <param name="options"></param>
         /// <param name="type"></param>
         /// <returns></returns>
-        Task<TSession?> VerifyOTP(string phone, string token, StatelessClientOptions options, MobileOtpType type = MobileOtpType.SMS);
+        Task<TSession?> VerifyOTP(string phone, string otpToken, StatelessClientOptions options, MobileOtpType type = MobileOtpType.SMS);
        
         /// <summary>
         /// Log in a user give a user supplied OTP received via email.
         /// </summary>
         /// <param name="email"></param>
-        /// <param name="token"></param>
+        /// <param name="otpToken"></param>
         /// <param name="options"></param>
         /// <param name="type"></param>
         /// <returns></returns>
-        Task<TSession?> VerifyOTP(string email, string token, StatelessClientOptions options, EmailOtpType type = EmailOtpType.MagicLink);
+        Task<TSession?> VerifyOTP(string email, string otpToken, StatelessClientOptions options, EmailOtpType type = EmailOtpType.MagicLink);
 
         /// <summary>
         /// Retrieve the current settings for the Gotrue instance.

--- a/Gotrue/Session.cs
+++ b/Gotrue/Session.cs
@@ -25,14 +25,18 @@ namespace Supabase.Gotrue
         public User? User { get; set; }
 
         [JsonProperty("created_at")]
-        public DateTime CreatedAt { get; set; } = DateTime.Now;
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
-        public DateTime ExpiresAt() => new DateTime(CreatedAt.Ticks).AddSeconds(ExpiresIn);
+        /// <summary>
+        /// The expiration date of this session, in UTC time.
+        /// </summary>
+        /// <returns></returns>
+        public DateTime ExpiresAt() => new DateTime(CreatedAt.Ticks).AddSeconds(ExpiresIn).ToUniversalTime();
         
         /// <summary>
         /// Returns true if the session has expired
         /// </summary>
         /// <returns></returns>
-        public bool Expired() => ExpiresAt() < DateTime.Now;
+        public bool Expired() => ExpiresAt() < DateTime.UtcNow;
     }
 }

--- a/Gotrue/StatelessClient.cs
+++ b/Gotrue/StatelessClient.cs
@@ -76,16 +76,11 @@ namespace Supabase.Gotrue
 
 					session = await api.SignInWithPhone(identifierOrToken, password!);
 					break;
-				case SignInType.RefreshToken:
-					session = await RefreshToken(identifierOrToken, options);
-					break;
 				default: throw new ArgumentOutOfRangeException(nameof(type), type, null);
 			}
 
 			if (session?.User?.ConfirmedAt != null || session?.User != null && options.AllowUnconfirmedUserSessions)
-			{
 				return session;
-			}
 
 			return null;
 		}

--- a/Gotrue/StatelessClient.cs
+++ b/Gotrue/StatelessClient.cs
@@ -94,17 +94,17 @@ namespace Supabase.Gotrue
 		public ProviderAuthState SignIn(Provider provider, StatelessClientOptions options, SignInOptions? signInOptions = null) => GetApi(options).GetUriForProvider(provider, signInOptions);
 
 		/// <inheritdoc />
-		public async Task<bool> SignOut(string jwt, StatelessClientOptions options)
+		public async Task<bool> SignOut(string accessToken, StatelessClientOptions options)
 		{
-			var result = await GetApi(options).SignOut(jwt);
+			var result = await GetApi(options).SignOut(accessToken);
 			result.ResponseMessage?.EnsureSuccessStatusCode();
 			return true;
 		}
 		
 		/// <inheritdoc />
-		public async Task<Session?> VerifyOTP(string phone, string token, StatelessClientOptions options, MobileOtpType type = MobileOtpType.SMS)
+		public async Task<Session?> VerifyOTP(string phone, string otpToken, StatelessClientOptions options, MobileOtpType type = MobileOtpType.SMS)
 		{
-			var session = await GetApi(options).VerifyMobileOTP(phone, token, type);
+			var session = await GetApi(options).VerifyMobileOTP(phone, otpToken, type);
 
 			if (session?.AccessToken != null)
 			{
@@ -115,9 +115,9 @@ namespace Supabase.Gotrue
 		}
 
 		/// <inheritdoc />
-		public async Task<Session?> VerifyOTP(string email, string token, StatelessClientOptions options, EmailOtpType type = EmailOtpType.MagicLink)
+		public async Task<Session?> VerifyOTP(string email, string otpToken, StatelessClientOptions options, EmailOtpType type = EmailOtpType.MagicLink)
 		{
-			var session = await GetApi(options).VerifyEmailOTP(email, token, type);
+			var session = await GetApi(options).VerifyEmailOTP(email, otpToken, type);
 
 			if (session?.AccessToken != null)
 			{
@@ -135,9 +135,9 @@ namespace Supabase.Gotrue
 		}
 
 		/// <inheritdoc />
-		public async Task<bool> InviteUserByEmail(string email, string jwt, StatelessClientOptions options)
+		public async Task<bool> InviteUserByEmail(string email, string serviceRoleToken, StatelessClientOptions options)
 		{
-			var response = await GetApi(options).InviteUserByEmail(email, jwt);
+			var response = await GetApi(options).InviteUserByEmail(email, serviceRoleToken);
 			response.ResponseMessage?.EnsureSuccessStatusCode();
 			return true;
 		}
@@ -151,50 +151,50 @@ namespace Supabase.Gotrue
 		}
 
 		/// <inheritdoc />
-		public async Task<UserList<User>?> ListUsers(string jwt, StatelessClientOptions options, string? filter = null, string? sortBy = null, SortOrder sortOrder = SortOrder.Descending,
+		public async Task<UserList<User>?> ListUsers(string serviceRoleToken, StatelessClientOptions options, string? filter = null, string? sortBy = null, SortOrder sortOrder = SortOrder.Descending,
 			int? page = null, int? perPage = null)
 		{
-			return await GetApi(options).ListUsers(jwt, filter, sortBy, sortOrder, page, perPage);
+			return await GetApi(options).ListUsers(serviceRoleToken, filter, sortBy, sortOrder, page, perPage);
 		}
 
 		/// <inheritdoc />
-		public async Task<User?> GetUserById(string jwt, StatelessClientOptions options, string userId)
+		public async Task<User?> GetUserById(string serviceRoleToken, StatelessClientOptions options, string userId)
 		{
-			return await GetApi(options).GetUserById(jwt, userId);
+			return await GetApi(options).GetUserById(serviceRoleToken, userId);
 		}
 
 		/// <inheritdoc />
-		public async Task<User?> GetUser(string jwt, StatelessClientOptions options)
+		public async Task<User?> GetUser(string serviceRoleToken, StatelessClientOptions options)
 		{
-			return await GetApi(options).GetUser(jwt);
+			return await GetApi(options).GetUser(serviceRoleToken);
 		}
 
 		/// <inheritdoc />
-		public Task<User?> CreateUser(string jwt, StatelessClientOptions options, string email, string password, AdminUserAttributes? attributes = null)
+		public Task<User?> CreateUser(string serviceRoleToken, StatelessClientOptions options, string email, string password, AdminUserAttributes? attributes = null)
 		{
 			attributes ??= new AdminUserAttributes();
 			attributes.Email = email;
 			attributes.Password = password;
 
-			return CreateUser(jwt, options, attributes);
+			return CreateUser(serviceRoleToken, options, attributes);
 		}
 
 		/// <inheritdoc />
-		public async Task<User?> CreateUser(string jwt, StatelessClientOptions options, AdminUserAttributes attributes)
+		public async Task<User?> CreateUser(string serviceRoleToken, StatelessClientOptions options, AdminUserAttributes attributes)
 		{
-			return await GetApi(options).CreateUser(jwt, attributes);
+			return await GetApi(options).CreateUser(serviceRoleToken, attributes);
 		}
 
 		/// <inheritdoc />
-		public async Task<User?> UpdateUserById(string jwt, StatelessClientOptions options, string userId, AdminUserAttributes userData)
+		public async Task<User?> UpdateUserById(string serviceRoleToken, StatelessClientOptions options, string userId, AdminUserAttributes userData)
 		{
-			return await GetApi(options).UpdateUserById(jwt, userId, userData);
+			return await GetApi(options).UpdateUserById(serviceRoleToken, userId, userData);
 		}
 
 		/// <inheritdoc />
-		public async Task<bool> DeleteUser(string uid, string jwt, StatelessClientOptions options)
+		public async Task<bool> DeleteUser(string uid, string serviceRoleToken, StatelessClientOptions options)
 		{
-			var result = await GetApi(options).DeleteUser(uid, jwt);
+			var result = await GetApi(options).DeleteUser(uid, serviceRoleToken);
 			result.ResponseMessage?.EnsureSuccessStatusCode();
 			return true;
 		}
@@ -244,7 +244,8 @@ namespace Supabase.Gotrue
 		}
 
 		/// <inheritdoc />
-		public async Task<Session?> RefreshToken(string refreshToken, StatelessClientOptions options) => await GetApi(options).RefreshAccessToken(refreshToken);
+		public async Task<Session?> RefreshToken(string accessToken, string refreshToken, StatelessClientOptions options) => 
+			await GetApi(options).RefreshAccessToken(accessToken, refreshToken);
 
 		/// <summary>
 		/// Class representation options available to the <see cref="Client"/>.

--- a/Gotrue/TokenRefresh.cs
+++ b/Gotrue/TokenRefresh.cs
@@ -104,7 +104,7 @@ namespace Supabase.Gotrue
 				// Interval should be t - (1/5(n)) (i.e. if session time (t) 3600s, attempt refresh at 2880s or 720s (1/5) seconds before expiration)
 				var interval = (int)Math.Floor(_client.CurrentSession.ExpiresIn * 4.0f / 5.0f);
 
-				var timeoutSeconds = Convert.ToInt32((_client.CurrentSession.CreatedAt.AddSeconds(interval) - DateTime.Now).TotalSeconds);
+				var timeoutSeconds = Convert.ToInt32((_client.CurrentSession.CreatedAt.AddSeconds(interval) - DateTime.UtcNow).TotalSeconds);
 
 				if (timeoutSeconds > _client.Options.MaximumRefreshWaitTime)
 					timeoutSeconds = _client.Options.MaximumRefreshWaitTime;

--- a/Gotrue/User.cs
+++ b/Gotrue/User.cs
@@ -65,7 +65,13 @@ namespace Supabase.Gotrue
 
         [JsonProperty("user_metadata")]
         public Dictionary<string, object> UserMetadata { get; set; } = new Dictionary<string, object>();
+        
+        [JsonProperty("exp")]
+        internal int? Exp { get; set; }
 
+        internal DateTime ExpiresAt() => Exp.HasValue ? DateTimeOffset.FromUnixTimeSeconds(Exp.Value).UtcDateTime : DateTime.MinValue;
+        
+        internal bool Expired() => ExpiresAt() < DateTime.UtcNow;
     }
 
     /// <summary>

--- a/GotrueTests/AnonKeyClientTests.cs
+++ b/GotrueTests/AnonKeyClientTests.cs
@@ -403,7 +403,7 @@ namespace GotrueTests
 			{
 				// Should be raised by `SetSession`
 				if (changed == SignedIn)
-					hasStateChangedTsc.SetResult(true);
+					hasStateChangedTsc.TrySetResult(true);
 			});
 			
 			await _client.SetSession(accessToken, refreshToken);
@@ -414,8 +414,18 @@ namespace GotrueTests
 			Assert.IsNotNull(_client.CurrentSession);
 			Assert.IsNotNull(_client.CurrentUser);
 			Assert.AreEqual(id, _client.CurrentUser.Id);
-			Assert.IsFalse(string.IsNullOrEmpty(_client.CurrentSession.AccessToken));
-			Assert.IsFalse(string.IsNullOrEmpty(_client.CurrentSession.RefreshToken));
+			
+			// As these are fresh, a new token should not be generated.
+			Assert.AreEqual(accessToken, _client.CurrentSession.AccessToken);
+			Assert.AreEqual(refreshToken, _client.CurrentSession.RefreshToken);
+			
+			await _client.SetSession(accessToken, refreshToken, forceAccessTokenRefresh: true);
+			Assert.IsNotNull(_client.CurrentSession);
+			Assert.IsNotNull(_client.CurrentUser);
+			Assert.AreEqual(id, _client.CurrentUser.Id);
+			
+			// As this is being forced to regenerate, the original should be different than the cached.
+			Assert.AreNotEqual(refreshToken, _client.CurrentSession.RefreshToken);
 		}
 	}
 }

--- a/GotrueTests/StatelessClientTests.cs
+++ b/GotrueTests/StatelessClientTests.cs
@@ -140,9 +140,7 @@ namespace GotrueTests
 			Assert.IsInstanceOfType(session.User, typeof(User));
 
 			// Refresh Token
-			var refreshToken = session.RefreshToken;
-
-			var newSession = await _client.SignIn(SignInType.RefreshToken, refreshToken, options: Options);
+			var newSession = await _client.RefreshToken(session.AccessToken, session.RefreshToken, Options);
 
 			Assert.IsNotNull(newSession.AccessToken);
 			Assert.IsNotNull(newSession.RefreshToken);

--- a/GotrueTests/StatelessClientTests.cs
+++ b/GotrueTests/StatelessClientTests.cs
@@ -48,7 +48,7 @@ namespace GotrueTests
 
 			var tokenDescriptor = new SecurityTokenDescriptor
 			{
-				IssuedAt = DateTime.Now,
+				IssuedAt = DateTime.UtcNow,
 				Expires = DateTime.UtcNow.AddDays(7),
 				SigningCredentials = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256Signature),
 				Claims = new Dictionary<string, object>()

--- a/GotrueTests/TestUtils.cs
+++ b/GotrueTests/TestUtils.cs
@@ -41,7 +41,7 @@ namespace GotrueTests
 
 			var tokenDescriptor = new SecurityTokenDescriptor
 			{
-				IssuedAt = DateTime.Now,
+				IssuedAt = DateTime.UtcNow,
 				Expires = DateTime.UtcNow.AddDays(7),
 				SigningCredentials = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256Signature),
 				Claims = new Dictionary<string, object>() { { "role", "service_role" } }


### PR DESCRIPTION
Provides breaking changes to fix #71.

**Overview:**
`Client.SetSession` will do the following:
1. Will destroy the current session (if existing)
2. Raise a `AuthState.SignedOut` event.
3. Decode token
  3a. If expired (or `forceAccessTokenRefresh` set), force an access token refresh.
  3b. If not expired, set the `CurrentSession` and retrieve `CurrentUser` from the server using the `accessToken`.
4. Raise a `AuthState.SignedIn` event if successful.

**Non-Breaking Changes:**
- Clarifies naming of parameters in `StatelessClient`, moving from `jwt` to `serviceRoleToken` when needed.

**Minor Breaking changes:**
- Removes `RefreshToken(string refreshToken)` and `SetAuth(string accessToken` in favor of `SetSession(string accessToken, string refreshToken)`
- Makes `RefreshAccessToken` require `accessToken` and `refreshToken` as parameters - overrides the authorization headers to use the supplied token
- Migrates project internal times to use `DateTime.UtcNow` over `DateTime.Now`.