### PR TITLE
Preserve token refresh interval

### DIFF
--- a/Gotrue/TokenRefresh.cs
+++ b/Gotrue/TokenRefresh.cs
@@ -90,9 +90,9 @@ namespace Supabase.Gotrue
 		/// If the user is offline, it won't try to refresh the token.
 		/// </summary>
 		private async void HandleRefreshTimerTick(object _)
-    {
-      try
-      {
+		{
+			try
+			{
 				if (_client.Online)
 					await _client.RefreshToken();
 			}


### PR DESCRIPTION
Fixes https://github.com/supabase-community/gotrue-csharp/issues/73

Before, the first token refresh happened after the configured interval. Then, token refreshes happened every 5s. Now, the configured interval is preserved. 

More: The `Timer` was disposed and recreated on each refresh. This is not necessary. Now the same timer is used for all refreshes.