### PR TITLE
Replace JWTDecoder package with System.IdentityModel.Tokens.Jwt

### DIFF
--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
 using System.Web;
 using Newtonsoft.Json;
@@ -415,12 +416,12 @@ namespace Supabase.Gotrue
 			if (string.IsNullOrEmpty(accessToken) || string.IsNullOrEmpty(refreshToken))
 				throw new GotrueException("`accessToken` and `refreshToken` cannot be empty.", NoSessionFound);
 
-			var payload = JWTDecoder.Decoder.DecodePayload<User>(accessToken);
+			var payload = new JwtSecurityTokenHandler().ReadJwtToken(accessToken).Payload;
 
-			if (payload == null || payload.ExpiresAt() == DateTime.MinValue)
+			if (payload == null || payload.ValidTo == DateTime.MinValue)
 				throw new GotrueException("`accessToken`'s payload was of an unknown structure.", NoSessionFound);
 
-			if (payload.Expired() || forceAccessTokenRefresh)
+			if (payload.ValidTo < DateTime.UtcNow || forceAccessTokenRefresh)
 			{
 				var result = await _api.RefreshAccessToken(accessToken, refreshToken);
 

--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -438,7 +438,7 @@ namespace Supabase.Gotrue
 				AccessToken = accessToken,
 				RefreshToken = refreshToken,
 				TokenType = "bearer",
-				ExpiresIn = payload.Exp!.Value,
+				ExpiresIn = payload.Expiration!.Value,
 				User = await _api.GetUser(accessToken)
 			};
 
@@ -485,7 +485,7 @@ namespace Supabase.Gotrue
 			var session = new Session
 			{
 				AccessToken = accessToken,
-				ExpiresIn = int.Parse(expiresIn),
+				ExpiresIn = long.Parse(expiresIn),
 				RefreshToken = refreshToken,
 				TokenType = tokenType,
 				User = user

--- a/Gotrue/Gotrue.csproj
+++ b/Gotrue/Gotrue.csproj
@@ -52,9 +52,9 @@
         <LangVersion>8.0</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="JWTDecoder" Version="0.9.2" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="supabase-core" Version="0.0.3" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.29.0" />
     </ItemGroup>
     <ItemGroup>
         <None Remove="Exceptions\" />

--- a/Gotrue/Gotrue.csproj
+++ b/Gotrue/Gotrue.csproj
@@ -54,7 +54,7 @@
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="supabase-core" Version="0.0.3" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.29.0" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
     </ItemGroup>
     <ItemGroup>
         <None Remove="Exceptions\" />

--- a/Gotrue/Session.cs
+++ b/Gotrue/Session.cs
@@ -13,7 +13,7 @@ namespace Supabase.Gotrue
         public string? AccessToken { get; set; }
 
         [JsonProperty("expires_in")]
-        public int ExpiresIn { get; set; }
+        public long ExpiresIn { get; set; }
 
         [JsonProperty("refresh_token")]
         public string? RefreshToken { get; set; }

--- a/Gotrue/StatelessClient.cs
+++ b/Gotrue/StatelessClient.cs
@@ -229,7 +229,7 @@ namespace Supabase.Gotrue
 			var session = new Session
 			{
 				AccessToken = accessToken,
-				ExpiresIn = int.Parse(expiresIn),
+				ExpiresIn = long.Parse(expiresIn),
 				RefreshToken = refreshToken,
 				TokenType = tokenType,
 				User = user

--- a/Gotrue/TokenRefresh.cs
+++ b/Gotrue/TokenRefresh.cs
@@ -160,9 +160,9 @@ namespace Supabase.Gotrue
 				return TimeSpan.Zero;
 			}
 
-			var interval = (int)Math.Floor(_client.CurrentSession.ExpiresIn * 4.0f / 5.0f);
+			var interval = (long)Math.Floor(_client.CurrentSession.ExpiresIn * 4.0f / 5.0f);
 
-			var timeoutSeconds = Convert.ToInt32((_client.CurrentSession.CreatedAt.AddSeconds(interval) - DateTime.UtcNow).TotalSeconds);
+			var timeoutSeconds = Convert.ToInt64((_client.CurrentSession.CreatedAt.AddSeconds(interval) - DateTime.UtcNow).TotalSeconds);
 
 			if (timeoutSeconds > _client.Options.MaximumRefreshWaitTime)
 				timeoutSeconds = _client.Options.MaximumRefreshWaitTime;

--- a/Gotrue/User.cs
+++ b/Gotrue/User.cs
@@ -68,10 +68,6 @@ namespace Supabase.Gotrue
         
         [JsonProperty("exp")]
         internal int? Exp { get; set; }
-
-        internal DateTime ExpiresAt() => Exp.HasValue ? DateTimeOffset.FromUnixTimeSeconds(Exp.Value).UtcDateTime : DateTime.MinValue;
-        
-        internal bool Expired() => ExpiresAt() < DateTime.UtcNow;
     }
 
     /// <summary>

--- a/GotrueTests/GotrueTests.csproj
+++ b/GotrueTests/GotrueTests.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.29.0" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-<PrivateAssets>all</PrivateAssets>
-</PackageReference>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.29.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The [JWTDecoder](https://www.nuget.org/packages/JWTDecoder) package only supports .NET Standard 2.0 and seems to introduce some problems with .NET Framework projects (see supabase-community/supabase-csharp#116).

This PR performs the following changes:
- Replaces the JWTDecoder package with [System.IdentityModel.Tokens.Jwt](https://www.nuget.org/packages/System.IdentityModel.Tokens.Jwt)
- Updates the package to its latest version (an older version was already referenced in the test project)