### PR TITLE
Allow for scoped signout

### DIFF
--- a/Gotrue/Api.cs
+++ b/Gotrue/Api.cs
@@ -542,12 +542,13 @@ namespace Supabase.Gotrue
 		/// Removes a logged-in session.
 		/// </summary>
 		/// <param name="jwt"></param>
+		/// <param name="scope"></param>
 		/// <returns></returns>
-		public Task<BaseResponse> SignOut(string jwt)
+		public Task<BaseResponse> SignOut(string jwt, SignOutScope scope = SignOutScope.Global)
 		{
 			var data = new Dictionary<string, string>();
 
-			return Helpers.MakeRequest(HttpMethod.Post, $"{Url}/logout", data, CreateAuthedRequestHeaders(jwt));
+			return Helpers.MakeRequest(HttpMethod.Post, $"{Url}/logout?scope={Core.Helpers.GetMappedToAttr(scope).Mapping}", data, CreateAuthedRequestHeaders(jwt));
 		}
 
 		/// <summary>

--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -401,9 +401,9 @@ namespace Supabase.Gotrue
 		}
 
 		/// <inheritdoc />
-		public async Task SignOut()
+		public async Task SignOut(SignOutScope scope = SignOutScope.Global)
 		{
-			if (CurrentSession?.AccessToken != null) await _api.SignOut(CurrentSession.AccessToken);
+			if (CurrentSession?.AccessToken != null) await _api.SignOut(CurrentSession.AccessToken, scope);
 			UpdateSession(null);
 			NotifyAuthStateChange(SignedOut);
 		}

--- a/Gotrue/Constants.cs
+++ b/Gotrue/Constants.cs
@@ -150,5 +150,15 @@ namespace Supabase.Gotrue
 			Email,
 			Phone
 		}
-	}
+
+        public enum SignOutScope
+        {
+            [MapTo("global")]
+            Global,
+            [MapTo("local")]
+            Local,
+            [MapTo("others")]
+            Others
+        }
+    }
 }

--- a/Gotrue/Interfaces/IGotrueApi.cs
+++ b/Gotrue/Interfaces/IGotrueApi.cs
@@ -31,7 +31,7 @@ namespace Supabase.Gotrue.Interfaces
 		Task<TSession?> SignInAnonymously(SignInAnonymouslyOptions? options = null);
 		Task<SSOResponse?> SignInWithSSO(Guid providerId, SignInWithSSOOptions? options = null);
 		Task<SSOResponse?> SignInWithSSO(string domain, SignInWithSSOOptions? options = null);
-		Task<BaseResponse> SignOut(string jwt);
+		Task<BaseResponse> SignOut(string jwt, SignOutScope scope = SignOutScope.Global);
 		Task<TSession?> SignUpWithEmail(string email, string password, SignUpOptions? options = null);
 		Task<TSession?> SignUpWithPhone(string phone, string password, SignUpOptions? options = null);
 		Task<TUser?> UpdateUser(string jwt, UserAttributes attributes);

--- a/Gotrue/Interfaces/IGotrueClient.cs
+++ b/Gotrue/Interfaces/IGotrueClient.cs
@@ -356,8 +356,9 @@ namespace Supabase.Gotrue.Interfaces
 		Task<bool> Reauthenticate();
 
 		/// <summary>
-		/// Signs out a user and invalidates the current token.
+		/// Signs out and invalidates all sessions for a user.
 		/// </summary>
+		/// <param name="scope">Determines which sessions should be invalidated. By default, it will invalidate all session for a user</param>
 		/// <returns></returns>
 		Task SignOut(SignOutScope scope = SignOutScope.Global);
 

--- a/Gotrue/Interfaces/IGotrueClient.cs
+++ b/Gotrue/Interfaces/IGotrueClient.cs
@@ -359,7 +359,7 @@ namespace Supabase.Gotrue.Interfaces
 		/// Signs out a user and invalidates the current token.
 		/// </summary>
 		/// <returns></returns>
-		Task SignOut();
+		Task SignOut(SignOutScope scope = SignOutScope.Global);
 
 		/// <summary>
 		/// Updates a User.


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds the ability to change the sign-out scopes from the default global scope.

## What is the current behavior?

Calling signout always signs out from the global scope. There is no way to change to a different scope.

## What is the new behavior?

Calling `signOut` now has a parameter to allow signing out from a different scope. To preserve backward compatibility and ensure parity with the js version, the parameter defaults to the global scope so there is no difference functionally.