### PR TITLE
Use a CSPRNG to generate the code verifier

### DIFF
--- a/Gotrue/Gotrue.csproj
+++ b/Gotrue/Gotrue.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <PackOnBuild>true</PackOnBuild>
         <PackageId>Supabase.Gotrue</PackageId>
         <RootNamespace>Supabase.Gotrue</RootNamespace>

--- a/Gotrue/Helpers.cs
+++ b/Gotrue/Helpers.cs
@@ -29,11 +29,10 @@ namespace Supabase.Gotrue
 		{
 			// ReSharper disable once StringLiteralTypo
 			const string chars = "abcdefghijklmnopqrstuvwxyz123456789";
-			var random = new Random();
 			var nonce = new char[128];
 			for (var i = 0; i < nonce.Length; i++)
 			{
-				nonce[i] = chars[random.Next(chars.Length)];
+				nonce[i] = chars[RandomNumberGenerator.GetInt32(0, chars.Length)];
 			}
 
 			return new string(nonce);


### PR DESCRIPTION
The PKCE for OAuth spec requires that the code verifier be a "high-entropy cryptographic random string": https://datatracker.ietf.org/doc/html/rfc7636#section-4.1

Previously, the ``GenerateNonce`` function was using ``System.Random`` to generate the code verifier, which is not cryptographically secure.

TargetFramework has been bumped to netstandard2.1 in order to get access to ``RandomNumberGenerator.GetInt32``.