### PR TITLE
Ban user functionality

### DIFF
--- a/Gotrue/User.cs
+++ b/Gotrue/User.cs
@@ -61,7 +61,10 @@ namespace Supabase.Gotrue
 		[JsonProperty("updated_at")]
 		public DateTime? UpdatedAt { get; set; }
 
-		[JsonProperty("is_anonymous")]
+        [JsonProperty("banned_until")]
+        public DateTime? BannedUntil { get; set; }
+
+        [JsonProperty("is_anonymous")]
 		public bool IsAnonymous { get; set; }
 
 		[JsonProperty("user_metadata")]
@@ -103,7 +106,20 @@ namespace Supabase.Gotrue
 		/// </summary>
 		[JsonProperty("phone_confirm")]
 		public bool? PhoneConfirm { get; set; }
-	}
+
+        /// <summary>
+        /// <para>Determines how long a user is banned for. </para>
+		/// <para>This property is ignored when creating a user.
+        /// If you want to create a user banned, first create the user then update it sending this property.</para>
+        /// <para>The format for the ban duration follows a strict sequence of decimal numbers with a unit suffix.
+        /// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".</para>
+        /// <para>For example, some possible durations include: '300ms', '2h45m', '1200s'.</para>
+		/// <para>Setting the ban duration to "none" lifts the ban on the user.</para>
+        /// <para>Only a service role can modify.</para>
+        /// </summary>
+        [JsonProperty("ban_duration")]
+        public string? BanDuration { get; set; }
+    }
 
 	/// <summary>
 	/// Ref: https://supabase.github.io/gotrue-js/interfaces/UserAttributes.html

--- a/Gotrue/User.cs
+++ b/Gotrue/User.cs
@@ -61,10 +61,10 @@ namespace Supabase.Gotrue
 		[JsonProperty("updated_at")]
 		public DateTime? UpdatedAt { get; set; }
 
-        [JsonProperty("banned_until")]
-        public DateTime? BannedUntil { get; set; }
+		[JsonProperty("banned_until")]
+		public DateTime? BannedUntil { get; set; }
 
-        [JsonProperty("is_anonymous")]
+		[JsonProperty("is_anonymous")]
 		public bool IsAnonymous { get; set; }
 
 		[JsonProperty("user_metadata")]
@@ -107,19 +107,19 @@ namespace Supabase.Gotrue
 		[JsonProperty("phone_confirm")]
 		public bool? PhoneConfirm { get; set; }
 
-        /// <summary>
-        /// <para>Determines how long a user is banned for. </para>
+		/// <summary>
+		/// <para>Determines how long a user is banned for. </para>
 		/// <para>This property is ignored when creating a user.
-        /// If you want to create a user banned, first create the user then update it sending this property.</para>
-        /// <para>The format for the ban duration follows a strict sequence of decimal numbers with a unit suffix.
-        /// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".</para>
-        /// <para>For example, some possible durations include: '300ms', '2h45m', '1200s'.</para>
+		/// If you want to create a user banned, first create the user then update it sending this property.</para>
+		/// <para>The format for the ban duration follows a strict sequence of decimal numbers with a unit suffix.
+		/// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".</para>
+		/// <para>For example, some possible durations include: '300ms', '2h45m', '1200s'.</para>
 		/// <para>Setting the ban duration to "none" lifts the ban on the user.</para>
-        /// <para>Only a service role can modify.</para>
-        /// </summary>
-        [JsonProperty("ban_duration")]
-        public string? BanDuration { get; set; }
-    }
+		/// <para>Only a service role can modify.</para>
+		/// </summary>
+		[JsonProperty("ban_duration")]
+		public string? BanDuration { get; set; }
+	}
 
 	/// <summary>
 	/// Ref: https://supabase.github.io/gotrue-js/interfaces/UserAttributes.html

--- a/GotrueExample/GotrueExample.csproj
+++ b/GotrueExample/GotrueExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GotrueTests/GotrueTests.csproj
+++ b/GotrueTests/GotrueTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/GotrueTests/ServiceRoleTests.cs
+++ b/GotrueTests/ServiceRoleTests.cs
@@ -140,31 +140,31 @@ namespace GotrueTests
 			AreNotEqual(createdUser.Email, updatedUser.Email);
 		}
 
-        [TestMethod("Service Role: Ban User by Id")]
-        public async Task BanUserById()
-        {
-            var createdUser = await _client.CreateUser($"{RandomString(12)}@supabase.io", PASSWORD);
+		[TestMethod("Service Role: Ban User by Id")]
+		public async Task BanUserById()
+		{
+			var createdUser = await _client.CreateUser($"{RandomString(12)}@supabase.io", PASSWORD);
 
-            IsNotNull(createdUser);
+			IsNotNull(createdUser);
 
-            int banDurationSeconds = RandomNumber();
-            DateTime bannedUntil = DateTime.UtcNow + TimeSpan.FromSeconds(banDurationSeconds);
-            var updatedUser = await _client.UpdateUserById(createdUser.Id ?? throw new InvalidOperationException(), new AdminUserAttributes { BanDuration = $"{banDurationSeconds}s" });
+			int banDurationSeconds = RandomNumber();
+			DateTime bannedUntil = DateTime.UtcNow + TimeSpan.FromSeconds(banDurationSeconds);
+			var updatedUser = await _client.UpdateUserById(createdUser.Id ?? throw new InvalidOperationException(), new AdminUserAttributes { BanDuration = $"{banDurationSeconds}s" });
 
-            IsNotNull(updatedUser);
+			IsNotNull(updatedUser);
 
-            AreEqual(createdUser.Id, updatedUser.Id);
-            IsNotNull(updatedUser.BannedUntil);
-            IsTrue((updatedUser.BannedUntil.Value - bannedUntil).Duration().TotalSeconds < 1);
+			AreEqual(createdUser.Id, updatedUser.Id);
+			IsNotNull(updatedUser.BannedUntil);
+			IsTrue((updatedUser.BannedUntil.Value - bannedUntil).Duration().TotalSeconds < 1);
 
 			updatedUser = await _client.UpdateUserById(createdUser.Id ?? throw new InvalidOperationException(), new AdminUserAttributes { BanDuration = "none" });
-            IsNotNull(updatedUser);
+			IsNotNull(updatedUser);
 
-            AreEqual(createdUser.Id, updatedUser.Id);
-            IsFalse(updatedUser.BannedUntil.HasValue);
-        }
+			AreEqual(createdUser.Id, updatedUser.Id);
+			IsFalse(updatedUser.BannedUntil.HasValue);
+		}
 
-        [TestMethod("Service Role: Delete User")]
+		[TestMethod("Service Role: Delete User")]
 		public async Task DeletesUser()
 		{
 			var email = $"{RandomString(12)}@supabase.io";

--- a/GotrueTests/ServiceRoleTests.cs
+++ b/GotrueTests/ServiceRoleTests.cs
@@ -140,7 +140,31 @@ namespace GotrueTests
 			AreNotEqual(createdUser.Email, updatedUser.Email);
 		}
 
-		[TestMethod("Service Role: Delete User")]
+        [TestMethod("Service Role: Ban User by Id")]
+        public async Task BanUserById()
+        {
+            var createdUser = await _client.CreateUser($"{RandomString(12)}@supabase.io", PASSWORD);
+
+            IsNotNull(createdUser);
+
+            int banDurationSeconds = RandomNumber();
+            DateTime bannedUntil = DateTime.UtcNow + TimeSpan.FromSeconds(banDurationSeconds);
+            var updatedUser = await _client.UpdateUserById(createdUser.Id ?? throw new InvalidOperationException(), new AdminUserAttributes { BanDuration = $"{banDurationSeconds}s" });
+
+            IsNotNull(updatedUser);
+
+            AreEqual(createdUser.Id, updatedUser.Id);
+            IsNotNull(updatedUser.BannedUntil);
+            IsTrue((updatedUser.BannedUntil.Value - bannedUntil).Duration().TotalSeconds < 1);
+
+			updatedUser = await _client.UpdateUserById(createdUser.Id ?? throw new InvalidOperationException(), new AdminUserAttributes { BanDuration = "none" });
+            IsNotNull(updatedUser);
+
+            AreEqual(createdUser.Id, updatedUser.Id);
+            IsFalse(updatedUser.BannedUntil.HasValue);
+        }
+
+        [TestMethod("Service Role: Delete User")]
 		public async Task DeletesUser()
 		{
 			var email = $"{RandomString(12)}@supabase.io";

--- a/GotrueTests/TestUtils.cs
+++ b/GotrueTests/TestUtils.cs
@@ -35,18 +35,18 @@ namespace GotrueTests
 			return $"+1{inner}";
 		}
 
-        /// <summary>
-        /// Returns a random number within the limits specified via parameters.
-        /// </summary>
-        /// <param name="minValue">Minimum value. Default 0.</param>
-        /// <param name="maxValue">Maximum value. Default 1000.</param>
-        /// <returns>Integer within the range.</returns>
-        public static int RandomNumber(int minValue = 0, int maxValue = 1000)
-        {
-            return Random.Next(minValue, maxValue);
-        }
+		/// <summary>
+		/// Returns a random number within the limits specified via parameters.
+		/// </summary>
+		/// <param name="minValue">Minimum value. Default 0.</param>
+		/// <param name="maxValue">Maximum value. Default 1000.</param>
+		/// <returns>Integer within the range.</returns>
+		public static int RandomNumber(int minValue = 0, int maxValue = 1000)
+		{
+			return Random.Next(minValue, maxValue);
+		}
 
-        public static string GenerateServiceRoleToken()
+		public static string GenerateServiceRoleToken()
 		{
 			var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("37c304f8-51aa-419a-a1af-06154e63707a")); // using GOTRUE_JWT_SECRET
 

--- a/GotrueTests/TestUtils.cs
+++ b/GotrueTests/TestUtils.cs
@@ -35,7 +35,18 @@ namespace GotrueTests
 			return $"+1{inner}";
 		}
 
-		public static string GenerateServiceRoleToken()
+        /// <summary>
+        /// Returns a random number within the limits specified via parameters.
+        /// </summary>
+        /// <param name="minValue">Minimum value. Default 0.</param>
+        /// <param name="maxValue">Maximum value. Default 1000.</param>
+        /// <returns>Integer within the range.</returns>
+        public static int RandomNumber(int minValue = 0, int maxValue = 1000)
+        {
+            return Random.Next(minValue, maxValue);
+        }
+
+        public static string GenerateServiceRoleToken()
 		{
 			var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("37c304f8-51aa-419a-a1af-06154e63707a")); // using GOTRUE_JWT_SECRET
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR adds the functionality to ban a user using the admin or stateless client.

## What is the current behavior?
Add properties to set BanDuration and BannedUtil to verify the datetime of the ban applied to the user. The information was submitted in issue #100 

## What is the new behavior?
Added a way to ban a user using property BanDuration and retrieving the information of banned user in property BannedUtil.

Defined unit testing passing
![image](https://github.com/user-attachments/assets/daddc0ed-5398-42b1-b390-0969435fbd72)

Added new test to show the functionality of banning a user and lifting the ban.
![image](https://github.com/user-attachments/assets/ed65c936-6ea8-4c63-b197-39c1ec4eca7c)

## Additional context
Also I updated the projects from Net7 (deprecated) to .Net8 (LTS).

If any other change is required let me know and I can work it 😊 