### PR TITLE
Add SignUp using UserAttributes class

### DIFF
--- a/Gotrue/Api.cs
+++ b/Gotrue/Api.cs
@@ -55,6 +55,7 @@ namespace Supabase.Gotrue
 			_headers = headers;
 		}
 
+
 		/// <summary>
 		/// Signs a user up using an email address and password.
 		/// </summary>
@@ -99,7 +100,61 @@ namespace Supabase.Gotrue
 			}
 			return null;
 		}
-
+	
+	
+	        /// <summary>
+	        /// Logs in an existing user using their email address.
+	        /// </summary>
+	        /// <param name="email"></param>
+	        /// <param name="password"></param>
+	        /// <returns></returns>
+	        public Task<Session> SignInWithEmail(UserAttributes attributes, SignUpOptions options = null)
+	        {
+	            string endpoint = $"{Url}/token?grant_type=password";
+	
+	            if (options != null)
+	            {
+	                if (!string.IsNullOrEmpty(options.RedirectTo))
+	                {
+	                    endpoint = Helpers.AddQueryParams(endpoint, new Dictionary<string, string> { { "redirect_to", options.RedirectTo } }).ToString();
+	                }
+	
+	                if (options.Data != null)
+	                {
+	                    attributes.Data.Add("data", options.Data);
+	                }
+	            }
+	            return Helpers.MakeRequest<Session>(HttpMethod.Post, endpoint, attributes, Headers);
+	        }
+	
+	        /// <summary>
+	        /// Signs up a new user using their phone number and a password.The phone number of the user.
+	        /// </summary>
+	        /// <param name="phone">The phone number of the user.</param>
+	        /// <param name="password">The password of the user.</param>
+	        /// <param name="options">Optional Signup data.</param>
+	        /// <returns></returns>
+	        public Task<Session> SignUpWithPhone(UserAttributes attributes, SignUpOptions options = null)
+	        {
+	
+	            string endpoint = $"{Url}/signup";
+	
+	            if (options != null)
+	            {
+	                if (!string.IsNullOrEmpty(options.RedirectTo))
+	                {
+	                    endpoint = Helpers.AddQueryParams(endpoint, new Dictionary<string, string> { { "redirect_to", options.RedirectTo } }).ToString();
+	                }
+	
+	                if (options.Data != null)
+	                {
+	                    attributes.Data.Add("data", options.Data);
+	                }
+	            }
+	
+	            return Helpers.MakeRequest<Session>(HttpMethod.Post, endpoint, attributes, Headers);
+        }
+	
 		/// <summary>
 		/// Logs in an existing user using their email address.
 		/// </summary>

--- a/Gotrue/Client.cs
+++ b/Gotrue/Client.cs
@@ -181,6 +181,72 @@ namespace Supabase.Gotrue
 			return session;
 		}
 
+                
+	        /// <summary>
+	        /// Signs up a user by email address
+	        /// </summary>
+	        /// <param name="email"></param>
+	        /// <param name="password"></param>
+	        /// <param name="options">Object containing redirectTo and optional user metadata (data)</param>
+	        /// <returns></returns>
+	        public Task<Session> SignUp(string email, string password, SignUpOptions options = null) => SignUp(SignUpType.Email, email, password, options);
+	
+	        public async Task<Session> SignUp(SignUpType type, UserAttributes attributes, SignUpOptions options = null)
+	        {
+	            await DestroySession();
+	
+	            try
+	            {
+	                Session session = null;
+	                switch (type)
+	                {
+	                    case SignUpType.Email:
+	                        session = await api.SignUpWithEmail(attributes, options);
+	                        break;
+	                    case SignUpType.Phone:
+	                        UnityEngine.Debug.LogError("Phone Sign in with User Attributes currently Unsupported");
+	                        session = await api.SignUpWithPhone(attributes, options);
+	                        break;
+	                }
+	
+	                if (session?.User?.ConfirmedAt != null || (session.User != null && Options.AllowUnconfirmedUserSessions))
+	                {
+	                    await PersistSession(session);
+	
+	                    StateChanged?.Invoke(this, new ClientStateChanged(AuthState.SignedIn));
+	
+	                    return CurrentSession;
+	                }
+	
+	                return session;
+	            }
+	            catch (RequestException ex)
+	            {
+	                Session session = null;
+	                if (ex.Response.StatusCode == System.Net.HttpStatusCode.UnprocessableEntity)
+	                {
+	                    UnityEngine.Debug.LogWarning($"User already exists, login user instead.");
+	                    switch (type)
+	                    {
+	                        case SignUpType.Email:
+	                            session = await api.SignInWithEmail(attributes);
+	                            break;
+	                        case SignUpType.Phone:
+	                            session = await api.SignUpWithPhone(attributes, options);
+	                            break;
+	                    }
+	
+	                    if (session?.User?.ConfirmedAt != null || (session.User != null && Options.AllowUnconfirmedUserSessions))
+	                    {
+	                        await PersistSession(session);
+	                        StateChanged?.Invoke(this, new ClientStateChanged(AuthState.SignedIn));
+	                        return CurrentSession;
+	                    }
+	                }
+	                return session;
+	            }
+	         }
+
 		/// <inheritdoc />
 		public async Task<bool> SignIn(string email, SignInOptions? options = null)
 		{


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

see [#166](https://github.com/supabase-community/supabase-csharp/issues/166)

## What is the new behavior?
users can use
`public async Task<Session> SignUp(SignUpType type, UserAttributes attributes, SignUpOptions options = null)`
to alternatively sign up as it seems the dictionary used by SignUp(sting username, string password) does not serialize
to json correctly. 

## Additional context

N/A
